### PR TITLE
Update to new maltoolbox 0.1.2

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -585,8 +585,8 @@ class MalSimulator(ParallelEnv):
                     self.agents_dict[agent]["attacker"]
                 ]
                 for node in attacker.reached_attack_steps:
-                    if hasattr(node, "reward"):
-                        reward += node.reward
+                    if hasattr(node, "extras"):
+                        reward += node.extras.get('reward', 0)
 
                 attackers_total_rewards += reward
                 rewards[agent] = reward
@@ -597,8 +597,8 @@ class MalSimulator(ParallelEnv):
             if self.agents_dict[agent]["type"] == "defender":
                 reward = -attackers_total_rewards
                 for node in query.get_enabled_defenses(self.attack_graph):
-                    if hasattr(node, "reward"):
-                        reward -= node.reward
+                    if hasattr(node, "extras"):
+                        reward -= node.extras.get('reward', 0)
                 rewards[agent] = reward
 
         for agent in self.agents:

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -286,6 +286,7 @@ class MalSimulator(ParallelEnv):
         logger.info("Initializing MAL ParralelEnv Simulator.")
         logger.debug("Creating and listing mapping tables.")
         self._index_to_id = [n.id for n in self.attack_graph.nodes]
+        self._index_to_full_name = [n.full_name for n in self.attack_graph.nodes]
         self._id_to_index = {n: i for i, n in enumerate(self._index_to_id)}
         str_format = "{:<5} {:<}\n"
         table = "\n" + str_format.format("Index", "Attack Step Id")

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -136,7 +136,7 @@ class MalSimulator(ParallelEnv):
 
     def asset_type(self, step):
         return (
-            self._asset_type_to_index[step.asset.metaconcept] + self.offset
+            self._asset_type_to_index[step.asset.type] + self.offset
             if step.name != "firstSteps"
             else 0
         )
@@ -144,7 +144,7 @@ class MalSimulator(ParallelEnv):
     def step_name(self, step):
         return (
             (
-                self._step_name_to_index[step.asset.metaconcept + ":" + step.name]
+                self._step_name_to_index[step.asset.type + ":" + step.name]
                 + self.offset
                 if not self.unholy
                 else self._unholy_step_name_to_index[step.attributes["name"]]

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -334,9 +334,9 @@ class MalSimulator(ParallelEnv):
         for agent in self.agents:
             if self.agents_dict[agent]["type"] == "attacker":
                 attacker = self.attack_graph.attackers[
-                    self.agents_dict[agent]["attacker"]]
-                self.action_surfaces[agent] = query.get_attack_surface(
-                    self.attack_graph, attacker)
+                    self.agents_dict[agent]["attacker"]
+                ]
+                self.action_surfaces[agent] = query.get_attack_surface(attacker)
             elif self.agents_dict[agent]["type"] == "defender":
                 self.action_surfaces[agent] = query.get_defense_surface(
                     self.attack_graph)
@@ -387,10 +387,10 @@ class MalSimulator(ParallelEnv):
                 attacker.compromise(attack_step_node)
                 self.action_surfaces[agent] = \
                     query.update_attack_surface_add_nodes(
-                        self.attack_graph,
                         attacker,
                         self.action_surfaces[agent],
-                        [attack_step_node])
+                        [attack_step_node]
+                    )
             actions.append(attack_step)
         else:
             logger.warning(

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -276,9 +276,9 @@ class MalSimulator(ParallelEnv):
 
     def reset(self, seed: Optional[int] = None, options: Optional[dict] = None):
         logger.info("Resetting simulator.")
-        attack_graph = AttackGraph()
-        attack_graph.load_from_file(self.attack_graph_backup_filename,
-            self.model)
+        attack_graph = AttackGraph.load_from_file(
+            self.attack_graph_backup_filename, self.model
+        )
         self.attack_graph = attack_graph
         return self.init(self.max_iter)
 

--- a/malsim/wrappers/wrapper.py
+++ b/malsim/wrappers/wrapper.py
@@ -27,9 +27,7 @@ class LazyWrapper(ParallelEnv):
 
         if attack_graph_file != "":
             # If we were provided with an attack graph file we load it.
-            attack_graph = AttackGraph()
-            attack_graph.load_from_file(filename = attack_graph_file,
-                model = model)
+            attack_graph = AttackGraph.load_from_file(attack_graph_file, model=model)
             attack_graph.model = model
             attack_graph.attach_attackers()
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
   "py2neo>=2021.2.3",
   "python-jsonschema-objects>=0.4.1",
-  "mal-toolbox==0.0.39",
+  "mal-toolbox==0.1.2",
   "numpy>=1.21.4",
   "pettingzoo>=1.24.2",
   "gymnasium>=0.29.1, <1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
   "py2neo>=2021.2.3",
   "python-jsonschema-objects>=0.4.1",
-  "mal-toolbox==0.1.2",
+  "mal-toolbox==0.1.4",
   "numpy>=1.21.4",
   "pettingzoo>=1.24.2",
   "gymnasium>=0.29.1, <1",

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -24,7 +24,7 @@ AGENT_DEFENDER = "defender"
 ACTION_TERMINATE = "terminate"
 ACTION_WAIT = "wait"
 
-model_file_name='tests/example_model.json'
+model_file_name='tests/example_model.yml'
 attack_graph_file_name=path.join('tmp','attack_graph.json')
 lang_file_name='tests/org.mal-lang.coreLang-1.0.0.mar'
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from malsim.sims.mal_simulator import MalSimulator
 
 from maltoolbox.wrappers import create_attack_graph
 
-model_file_name='tests/example_model.json'
+model_file_name='tests/example_model.yml'
 attack_graph_file_name=path.join('tmp','attack_graph.json')
 lang_file_name='tests/org.mal-lang.coreLang-1.0.0.mar'
 

--- a/tests/example_model.yml
+++ b/tests/example_model.yml
@@ -3,13 +3,13 @@ assets:
     defenses:
       notPresent: 0.0
       supplyChainAuditing: 0.0
-    metaconcept: Application
+    type: Application
     name: OS App
   1:
     defenses:
       notPresent: 0.0
       supplyChainAuditing: 0.0
-    metaconcept: Application
+    type: Application
     name: Program 1
   2:
     defenses:
@@ -24,79 +24,72 @@ assets:
       notPresent: 0.0
       physicalAccessRequired: 0.0
       userInteractionRequired: 0.0
-    metaconcept: SoftwareVulnerability
+    type: SoftwareVulnerability
     name: SoftwareVulnerability:2
   3:
     defenses:
       notPresent: 0.0
-    metaconcept: Data
+    type: Data
     name: Data:3
   4:
     defenses:
       notPhishable: 0.0
-    metaconcept: Credentials
+    type: Credentials
     name: Credentials:4
   5:
     defenses:
       notPresent: 0.0
-    metaconcept: Identity
+    type: Identity
     name: Identity:5
   6:
     defenses:
       payloadInspection: 0.0
       restricted: 0.0
-    metaconcept: ConnectionRule
+    type: ConnectionRule
     name: ConnectionRule:6
   7:
     defenses:
       notPresent: 0.0
       supplyChainAuditing: 0.0
-    metaconcept: Application
+    type: Application
     name: Other OS App
 associations:
-- association:
+- AppExecution:
     appExecutedApps:
     - 1
     hostApp:
     - 0
-  metaconcept: AppExecution
-- association:
+- ApplicationVulnerability_SoftwareVulnerability_Application:
     application:
     - 0
     vulnerabilities:
     - 2
-  metaconcept: ApplicationVulnerability_SoftwareVulnerability_Application
-- association:
+- AppContainment:
     containedData:
     - 3
     containingApp:
     - 1
-  metaconcept: AppContainment
-- association:
+- IdentityCredentials:
     credentials:
     - 4
     identities:
     - 5
-  metaconcept: IdentityCredentials
-- association:
+- InfoContainment:
     containerData:
     - 3
     information:
     - 4
-  metaconcept: InfoContainment
-- association:
+- ApplicationConnection:
     appConnections:
     - 6
     applications:
     - 0
     - 7
-  metaconcept: ApplicationConnection
-- association:
+- ExecutionPrivilegeAccess:
     execPrivApps:
     - 7
     executionPrivIAMs:
     - 5
-  metaconcept: ExecutionPrivilegeAccess
 attackers:
   8:
     entry_points:

--- a/tests/run_demo.py
+++ b/tests/run_demo.py
@@ -81,23 +81,23 @@ done = False
 # scenario configuration format decided upon.
 MAX_REWARD = int(1e9)
 
-env.attack_graph.get_node_by_full_name("OS App:notPresent").reward = 50
-env.attack_graph.get_node_by_full_name("OS App:supplyChainAuditing").reward = MAX_REWARD
-env.attack_graph.get_node_by_full_name("Program 1:notPresent").reward = 30
-env.attack_graph.get_node_by_full_name("Program 1:supplyChainAuditing").reward = MAX_REWARD
-env.attack_graph.get_node_by_full_name("SoftwareVulnerability:2:notPresent").reward = 40
-env.attack_graph.get_node_by_full_name("Data:3:notPresent").reward = 20
-env.attack_graph.get_node_by_full_name("Credentials:4:notPhishable").reward = MAX_REWARD
-env.attack_graph.get_node_by_full_name("Identity:5:notPresent").reward = 35
-env.attack_graph.get_node_by_full_name("ConnectionRule:6:restricted").reward = 40
-env.attack_graph.get_node_by_full_name("ConnectionRule:6:payloadInspection").reward = 30
-env.attack_graph.get_node_by_full_name("Other OS App:notPresent").reward = 50
-env.attack_graph.get_node_by_full_name("Other OS App:supplyChainAuditing").reward = MAX_REWARD
+env.attack_graph.get_node_by_full_name("OS App:notPresent").extras['reward'] = 50
+env.attack_graph.get_node_by_full_name("OS App:supplyChainAuditing").extras['reward'] = MAX_REWARD
+env.attack_graph.get_node_by_full_name("Program 1:notPresent").extras['reward'] = 30
+env.attack_graph.get_node_by_full_name("Program 1:supplyChainAuditing").extras['reward'] = MAX_REWARD
+env.attack_graph.get_node_by_full_name("SoftwareVulnerability:2:notPresent").extras['reward'] = 40
+env.attack_graph.get_node_by_full_name("Data:3:notPresent").extras['reward'] = 20
+env.attack_graph.get_node_by_full_name("Credentials:4:notPhishable").extras['reward'] = MAX_REWARD
+env.attack_graph.get_node_by_full_name("Identity:5:notPresent").extras['reward'] = 35
+env.attack_graph.get_node_by_full_name("ConnectionRule:6:restricted").extras['reward'] = 40
+env.attack_graph.get_node_by_full_name("ConnectionRule:6:payloadInspection").extras['reward'] = 30
+env.attack_graph.get_node_by_full_name("Other OS App:notPresent").extras['reward'] = 50
+env.attack_graph.get_node_by_full_name("Other OS App:supplyChainAuditing").extras['reward'] = MAX_REWARD
 
-env.attack_graph.get_node_by_full_name("OS App:fullAccess").reward = 100
-env.attack_graph.get_node_by_full_name("Program 1:fullAccess").reward = 50
-env.attack_graph.get_node_by_full_name("Identity:5:assume").reward = 50
-env.attack_graph.get_node_by_full_name("Other OS App:fullAccess").reward = 200
+env.attack_graph.get_node_by_full_name("OS App:fullAccess").extras['reward'] = 100
+env.attack_graph.get_node_by_full_name("Program 1:fullAccess").extras['reward'] = 50
+env.attack_graph.get_node_by_full_name("Identity:5:assume").extras['reward'] = 50
+env.attack_graph.get_node_by_full_name("Other OS App:fullAccess").extras['reward'] = 200
 
 
 logger.info("Starting game.")

--- a/tests/run_demo.py
+++ b/tests/run_demo.py
@@ -66,7 +66,7 @@ env.register_defender(AGENT_DEFENDER)
 
 control_attacker = False
 
-reverse_vocab = env._index_to_id
+reverse_vocab = env._index_to_full_name
 
 defender = KeyboardAgent(reverse_vocab)
 attacker = (

--- a/tests/run_demo.py
+++ b/tests/run_demo.py
@@ -54,7 +54,7 @@ lang_classes_factory = LanguageClassesFactory(lang_graph)
 lang_graph = LanguageGraph.from_mar_archive(lang_file)
 lang_classes_factory = LanguageClassesFactory(lang_graph)
 
-model = Model.load_from_file("tests/testdata/example_model_0.1.2.json", lang_classes_factory)
+model = Model.load_from_file("tests/example_model.yml", lang_classes_factory)
 
 attack_graph = AttackGraph(lang_graph, model)
 attack_graph.attach_attackers()

--- a/tests/run_demo.py
+++ b/tests/run_demo.py
@@ -80,23 +80,24 @@ done = False
 # TODO Have a nice and configurable way of doing this when we have the
 # scenario configuration format decided upon.
 MAX_REWARD = int(1e9)
-env.attack_graph.get_node_by_id("OS App:notPresent").reward = 50
-env.attack_graph.get_node_by_id("OS App:supplyChainAuditing").reward = MAX_REWARD
-env.attack_graph.get_node_by_id("Program 1:notPresent").reward = 30
-env.attack_graph.get_node_by_id("Program 1:supplyChainAuditing").reward = MAX_REWARD
-env.attack_graph.get_node_by_id("SoftwareVulnerability:2:notPresent").reward = 40
-env.attack_graph.get_node_by_id("Data:3:notPresent").reward = 20
-env.attack_graph.get_node_by_id("Credentials:4:notPhishable").reward = MAX_REWARD
-env.attack_graph.get_node_by_id("Identity:5:notPresent").reward = 35
-env.attack_graph.get_node_by_id("ConnectionRule:6:restricted").reward = 40
-env.attack_graph.get_node_by_id("ConnectionRule:6:payloadInspection").reward = 30
-env.attack_graph.get_node_by_id("Other OS App:notPresent").reward = 50
-env.attack_graph.get_node_by_id("Other OS App:supplyChainAuditing").reward = MAX_REWARD
 
-env.attack_graph.get_node_by_id("OS App:fullAccess").reward = 100
-env.attack_graph.get_node_by_id("Program 1:fullAccess").reward = 50
-env.attack_graph.get_node_by_id("Identity:5:assume").reward = 50
-env.attack_graph.get_node_by_id("Other OS App:fullAccess").reward = 200
+env.attack_graph.get_node_by_full_name("OS App:notPresent").reward = 50
+env.attack_graph.get_node_by_full_name("OS App:supplyChainAuditing").reward = MAX_REWARD
+env.attack_graph.get_node_by_full_name("Program 1:notPresent").reward = 30
+env.attack_graph.get_node_by_full_name("Program 1:supplyChainAuditing").reward = MAX_REWARD
+env.attack_graph.get_node_by_full_name("SoftwareVulnerability:2:notPresent").reward = 40
+env.attack_graph.get_node_by_full_name("Data:3:notPresent").reward = 20
+env.attack_graph.get_node_by_full_name("Credentials:4:notPhishable").reward = MAX_REWARD
+env.attack_graph.get_node_by_full_name("Identity:5:notPresent").reward = 35
+env.attack_graph.get_node_by_full_name("ConnectionRule:6:restricted").reward = 40
+env.attack_graph.get_node_by_full_name("ConnectionRule:6:payloadInspection").reward = 30
+env.attack_graph.get_node_by_full_name("Other OS App:notPresent").reward = 50
+env.attack_graph.get_node_by_full_name("Other OS App:supplyChainAuditing").reward = MAX_REWARD
+
+env.attack_graph.get_node_by_full_name("OS App:fullAccess").reward = 100
+env.attack_graph.get_node_by_full_name("Program 1:fullAccess").reward = 50
+env.attack_graph.get_node_by_full_name("Identity:5:assume").reward = 50
+env.attack_graph.get_node_by_full_name("Other OS App:fullAccess").reward = 200
 
 
 logger.info("Starting game.")

--- a/tests/run_demo.py
+++ b/tests/run_demo.py
@@ -54,12 +54,11 @@ lang_classes_factory = LanguageClassesFactory(lang_graph)
 lang_graph = LanguageGraph.from_mar_archive(lang_file)
 lang_classes_factory = LanguageClassesFactory(lang_graph)
 
-model = Model.load_from_file("tests/example_model.yml", lang_classes_factory)
+model = Model.load_from_file("tests/testdata/example_model_0.1.2.json", lang_classes_factory)
 
 attack_graph = AttackGraph(lang_graph, model)
 attack_graph.attach_attackers()
 attack_graph.save_to_file("tmp/attack_graph.json")
-
 env = MalSimulator(lang_graph, model, attack_graph, max_iter=500)
 
 env.register_attacker(AGENT_ATTACKER, 0)

--- a/tests/testdata/example_model_0.1.2.json
+++ b/tests/testdata/example_model_0.1.2.json
@@ -1,0 +1,261 @@
+{
+  "metadata": {
+    "name": "Simple Example Model",
+    "langVersion": "1.0.0",
+    "langID": "org.mal-lang.coreLang",
+    "malVersion": "0.1.0-SNAPSHOT",
+    "info": "Created by the mal-toolbox model python module."
+  },
+  "assets": {
+    "0": {
+      "name": "OS App",
+      "type": "Application",
+      "defenses": {
+        "notPresent": 0.0,
+        "supplyChainAuditing": 0.0
+      }
+    },
+    "1": {
+      "name": "Program 1",
+      "type": "Application",
+      "defenses": {
+        "notPresent": 1.0,
+        "supplyChainAuditing": 0.0
+      }
+    },
+    "2": {
+      "name": "Program 1:2",
+      "type": "Application",
+      "defenses": {
+        "notPresent": 0.0,
+        "supplyChainAuditing": 0.0
+      }
+    },
+    "3": {
+      "name": "IDPS 1",
+      "type": "IDPS",
+      "defenses": {
+        "notPresent": 0.0,
+        "supplyChainAuditing": 0.0
+      }
+    },
+    "4": {
+      "name": "SoftwareVulnerability:4",
+      "type": "SoftwareVulnerability",
+      "defenses": {
+        "notPresent": 0.0,
+        "networkAccessRequired": 0.0,
+        "localAccessRequired": 0.0,
+        "physicalAccessRequired": 0.0,
+        "lowPrivilegesRequired": 1.0,
+        "highPrivilegesRequired": 0.0,
+        "userInteractionRequired": 0.0,
+        "confidentialityImpactLimitations": 0.0,
+        "availabilityImpactLimitations": 1.0,
+        "integrityImpactLimitations": 0.0,
+        "highComplexityExploitRequired": 0.0
+      }
+    },
+    "5": {
+      "name": "Data:5",
+      "type": "Data",
+      "defenses": {
+        "notPresent": 0.0
+      }
+    },
+    "6": {
+      "name": "Credentials:6",
+      "type": "Credentials",
+      "defenses": {
+        "unique": 0.0,
+        "notPhishable": 0.0
+      }
+    },
+    "7": {
+      "name": "Credentials:7",
+      "type": "Credentials",
+      "defenses": {
+        "unique": 0.0,
+        "notPhishable": 0.0
+      }
+    },
+    "8": {
+      "name": "Identity:8",
+      "type": "Identity",
+      "defenses": {
+        "notPresent": 0.0
+      }
+    },
+    "9": {
+      "name": "Credentials:9",
+      "type": "Credentials",
+      "defenses": {
+        "unique": 0.0,
+        "notPhishable": 0.0
+      }
+    },
+    "10": {
+      "name": "Credentials:10",
+      "type": "Credentials",
+      "defenses": {
+        "notPhishable": 0.0
+      }
+    },
+    "11": {
+      "name": "Identity:11",
+      "type": "Identity",
+      "defenses": {
+        "notPresent": 0.0
+      }
+    },
+    "12": {
+      "name": "User:12",
+      "type": "User",
+      "defenses": {
+        "noPasswordReuse": 0.0,
+        "securityAwareness": 0.0
+      }
+    },
+    "13": {
+      "name": "Group:13",
+      "type": "Group",
+      "defenses": {
+        "notPresent": 0.0
+      }
+    }
+  },
+  "associations": [
+    {
+      "AppExecution": {
+        "hostApp": [
+          0
+        ],
+        "appExecutedApps": [
+          1,
+          2,
+          3
+        ]
+      }
+    },
+    {
+      "ApplicationVulnerability_SoftwareVulnerability_Application": {
+        "vulnerabilities": [
+          4
+        ],
+        "application": [
+          2
+        ]
+      }
+    },
+    {
+      "AppContainment": {
+        "containedData": [
+          5
+        ],
+        "containingApp": [
+          2
+        ]
+      }
+    },
+    {
+      "EncryptionCredentials": {
+        "encryptCreds": [
+          6
+        ],
+        "encryptedData": [
+          5
+        ]
+      }
+    },
+    {
+      "ConditionalAuthentication": {
+        "credentials": [
+          6
+        ],
+        "requiredFactors": [
+          7
+        ]
+      }
+    },
+    {
+      "IdentityCredentials": {
+        "identities": [
+          8
+        ],
+        "credentials": [
+          6
+        ]
+      }
+    },
+    {
+      "IdentityCredentials": {
+        "identities": [
+          11
+        ],
+        "credentials": [
+          9,
+          10
+        ]
+      }
+    },
+    {
+      "UserAssignedIdentities": {
+        "users": [
+          12
+        ],
+        "userIds": [
+          8,
+          11
+        ]
+      }
+    },
+    {
+      "Dependence_Information_Application": {
+        "infoDependedUpon": [
+          13
+        ],
+        "dependentApps": [
+          3
+        ]
+      }
+    }
+  ],
+  "attackers": {
+    "14": {
+      "name": "Attacker:14",
+      "entry_points": {
+        "6": {
+          "attack_steps": [
+            "attemptCredentialsReuse"
+          ]
+        },
+        "7": {
+          "attack_steps": [
+            "attemptCredentialsReuse",
+            "guessCredentials"
+          ]
+        },
+        "0": {
+          "attack_steps": [
+            "softwareProductAbuse"
+          ]
+        },
+        "9": {
+          "attack_steps": [
+            "attemptCredentialsReuse"
+          ]
+        }
+      }
+    },
+    "15": {
+      "name": "Attacker:15",
+      "entry_points": {
+        "0": {
+          "attack_steps": [
+            "fullAccess"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adapts MAL Simulator to the newest maltoolbox version.

Note: This also assumes that the maltoolbox bugfixes are merged https://github.com/mal-lang/mal-toolbox/pull/67

What was done:

- Use latest maltoolbox version (0.1.4)
- Refer to type instead of metaconcept
- follow new AttackGraph.load_from_file API
- follow new api for maltoolbox methods where unused args were removed 
- convert the example_model to new format and use it in api_test.py and run_demo
- use get_node_by_full_name instead of by_id
- use fulll_name instead of id when creating the vocab for the Keyboard Agent