### PR TITLE
Add optional parameter to MalSimulator __init__  and only prune if True

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -91,14 +91,24 @@ class MalSimulator(ParallelEnv):
         model: Model,
         attack_graph: AttackGraph,
         max_iter=ITERATIONS_LIMIT,
+        prune_unviable_unnecessary: bool = True,
         **kwargs,
     ):
+        """
+        Args:
+            lang_graph                  -   The language graph to use
+            model                       -   The model to use
+            attack_graph                -   The attack graph to use
+            max_iter                    -   Max iterations in simulation
+            prune_unviable_unnecessary  -   Prunes graph if set to true
+        """
         super().__init__()
         logger.info("Create Mal Simulator.")
         self.lang_graph = lang_graph
         self.model = model
         apriori.calculate_viability_and_necessity(attack_graph)
-        apriori.prune_unviable_and_unnecessary_nodes(attack_graph)
+        if prune_unviable_unnecessary:
+            apriori.prune_unviable_and_unnecessary_nodes(attack_graph)
         self.attack_graph = attack_graph
         self.max_iter = max_iter
         self.attack_graph_backup_filename = \


### PR DESCRIPTION
Not sure if this is actually needed, but I noticed:

Some nodes disappear with 'prune_unviable_and_unnecessary_nodes'. 
This is a problem when the nodes that are pruned are used as attacker entry points.
Then the loading of the attack graph will crash since the attacker entry points can not be found in the graph.

Maybe the solution is to make it optional? I don't know.