### PR TITLE
Make sure reached attack steps are not marked with 0 in observation

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -620,6 +620,11 @@ class MalSimulator(ParallelEnv):
 
         for node in attacker.reached_attack_steps:
             for child_node in node.children:
+                if child_node in attacker.reached_attack_steps:
+                    # Reached attack steps are kept active.
+                    continue
+
+                # Children of reached attack steps are inactive.
                 child_node_index = self._id_to_index[child_node.id]
                 observation["observed_state"][child_node_index] = 0
 

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -623,7 +623,6 @@ class MalSimulator(ParallelEnv):
                 if child_node in attacker.reached_attack_steps:
                     # Reached attack steps are kept active.
                     continue
-
                 # Children of reached attack steps are inactive.
                 child_node_index = self._id_to_index[child_node.id]
                 observation["observed_state"][child_node_index] = 0

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1,0 +1,41 @@
+from malsim.scenario import load_scenario
+from malsim.sims.mal_simulator import MalSimulator
+
+def test():
+    attack_graph, conf = load_scenario(
+        'tests/testdata/scenarios/simple_scenario.yml'
+    )
+
+    # Make alteration to the attack graph attacker
+    assert len(attack_graph.attackers) == 1
+    attacker = attack_graph.attackers[0]
+    assert len(attacker.reached_attack_steps) == 1
+    reached_step = attacker.reached_attack_steps[0]
+    for child_node in reached_step.children:
+        if child_node.type in ('and', 'or'):
+            # compromise children of reached step so in the end the
+            # attacker will have three reached attack steps where
+            # two are children of the first one
+            attacker.compromise(child_node)
+    assert len(attacker.reached_attack_steps) == 3
+
+    #Create the simulator
+    sim = MalSimulator(
+        attack_graph.lang_graph, attack_graph.model, attack_graph)
+
+    # Register the agents
+    attacker_agent_id = "attacker"
+    defender_agent_if = "defender"
+    sim.register_attacker(attacker_agent_id, 0)
+    sim.register_defender(defender_agent_if)
+
+    obs, _ = sim.reset()
+
+    attacker_agent_id = next(iter(sim.get_attacker_agents()))
+    attacker_observation = obs[attacker_agent_id]["observed_state"]
+    attacker = sim.attack_graph.attackers[0]
+
+    for node in attacker.reached_attack_steps:
+        node_index = sim._id_to_index[node.id]
+        node_obs_state = attacker_observation[node_index]
+        assert node_obs_state == 1


### PR DESCRIPTION
If a reached attack step was a child of another reached attack step, it would be marked as 0 in the attacker observation, although it should be 1.

This fixes that bug. 
