### PR TITLE
Simulator settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ through the parameter 'sim_settings'. Giving sim_settings is optional, otherwise
 
 settings = MalSimulatorSettings(
   uncompromise_untraversable_steps=True, # default is False
-  cumulative_actions_in_defender_obs=False # default is True
+  cumulative_defender_obs=False # default is True
 )
 sim = MalSimulator(lang_graph, model, attack_graph, sim_settings=settings)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,23 @@ A MAL compliant simulator.
 ## Installation
 ```pip install mal-simulator```
 
-Use the malsim CLI to run run simulations on scenarios.
+## MalSimulator
+
+A `sims.mal_simulator.MalSimulator` can be created to be able to run simulations.
+
+### MalSimulatorSettings
+The constructor of MalSimulator can be given a settings object (`sims.mal_simulator.MalSimulatorSettings`)
+through the parameter 'sim_settings'. Giving sim_settings is optional, otherwise default settings are used.
+
+```python
+
+settings = MalSimulatorSettings(
+  uncompromise_untraversable_steps=True, # default is False
+  cumulative_actions_in_defender_obs=False # default is True
+)
+sim = MalSimulator(lang_graph, model, attack_graph, sim_settings=settings)
+
+```
 
 ## Scenarios
 

--- a/malsim/sims/__init__.py
+++ b/malsim/sims/__init__.py
@@ -1,0 +1,2 @@
+from .mal_simulator import MalSimulator
+from .mal_simulator_settings import MalSimulatorSettings

--- a/malsim/sims/__init__.py
+++ b/malsim/sims/__init__.py
@@ -1,2 +1,2 @@
-from .mal_simulator import MalSimulator
-from .mal_simulator_settings import MalSimulatorSettings
+from .mal_simulator import MalSimulator as MalSimulator
+from .mal_simulator_settings import MalSimulatorSettings as MalSimulatorSettings

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -598,7 +598,7 @@ class MalSimulator(ParallelEnv):
                 observation["observed_state"][node_index] = 0
                 untraversable_nodes.append(node)
 
-        if self.sim_settings.evict_attacker_from_defended_step:
+        if self.sim_settings.uncompromise_untraversable_steps:
             # Uncompromise nodes that are not traversable.
             for node in untraversable_nodes:
                 logger.debug(
@@ -627,7 +627,7 @@ class MalSimulator(ParallelEnv):
         # we do not have to go through the list of nodes every time. In case
         # we have multiple defenders
 
-        if self.sim_settings.remember_previous_steps_in_defender_obs:
+        if self.sim_settings.cumulative_actions_in_defender_obs:
             # Show all active steps
             for node in self.attack_graph.nodes:
                 index = self._id_to_index[node.id]

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -627,7 +627,7 @@ class MalSimulator(ParallelEnv):
         # we do not have to go through the list of nodes every time. In case
         # we have multiple defenders
 
-        if self.sim_settings.cumulative_actions_in_defender_obs:
+        if self.sim_settings.cumulative_defender_obs:
             # Show all active steps
             for node in self.attack_graph.nodes:
                 index = self._id_to_index[node.id]

--- a/malsim/sims/mal_simulator_settings.py
+++ b/malsim/sims/mal_simulator_settings.py
@@ -11,8 +11,8 @@ class MalSimulatorSettings():
     # - Leave the node/step compromised even after it becomes untraversable
     uncompromise_untraversable_steps: bool = False
 
-    # cumulative_actions_in_defender_obs
+    # cumulative_defender_obs
     # - Defender sees the status of the whole attack graph if set to True
     # otherwise:
     # - Defender only sees the status of nodes changed in the current step
-    cumulative_actions_in_defender_obs: bool = True
+    cumulative_defender_obs: bool = True

--- a/malsim/sims/mal_simulator_settings.py
+++ b/malsim/sims/mal_simulator_settings.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass
+
+@dataclass
+class MalSimulatorSettings():
+    """Contains settings used in MalSimulator"""
+    # Attacker observation settings
+    evict_attacker_from_defended_step: bool = False
+    # Defender observation settings
+    show_previous_steps_in_defender_observation: bool = True

--- a/malsim/sims/mal_simulator_settings.py
+++ b/malsim/sims/mal_simulator_settings.py
@@ -3,7 +3,16 @@ from dataclasses import dataclass
 @dataclass
 class MalSimulatorSettings():
     """Contains settings used in MalSimulator"""
-    # Attacker observation settings
-    evict_attacker_from_defended_step: bool = False
-    # Defender observation settings
-    remember_previous_steps_in_defender_obs: bool = True
+
+    # uncompromise_untraversable_steps
+    # - Uncompromise (evict attacker) from nodes/steps that are no longer
+    #   traversable (often because a defense kicked in) if set to True
+    # otherwise:
+    # - Leave the node/step compromised even after it becomes untraversable
+    uncompromise_untraversable_steps: bool = False
+
+    # cumulative_actions_in_defender_obs
+    # - Defender sees the status of the whole attack graph if set to True
+    # otherwise:
+    # - Defender only sees the status of nodes changed in the current step
+    cumulative_actions_in_defender_obs: bool = True

--- a/malsim/sims/mal_simulator_settings.py
+++ b/malsim/sims/mal_simulator_settings.py
@@ -6,4 +6,4 @@ class MalSimulatorSettings():
     # Attacker observation settings
     evict_attacker_from_defended_step: bool = False
     # Defender observation settings
-    show_previous_steps_in_defender_observation: bool = True
+    remember_previous_steps_in_defender_obs: bool = True

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -383,10 +383,10 @@ def test_default_simulator_settings_eviction():
 
 
 def test_simulator_settings_evict_attacker():
-    """Test using the MalSimulatorSettings when not evicting attacker"""
+    """Test using the MalSimulatorSettings when evicting attacker"""
 
     settings_evict_attacker = MalSimulatorSettings(
-        evict_attacker_from_defended_step=True
+        uncompromise_untraversable_steps=True
     )
 
     sim, _ = create_simulator_from_scenario(
@@ -434,7 +434,7 @@ def test_simulator_settings_evict_attacker():
     assert attacker not in user_3_compromise.compromised_by
 
 def test_simulator_default_settings_defender_observation():
-    """Test MalSimulatorSettings remember previous steps"""
+    """Test MalSimulatorSettings show previous steps in obs"""
 
     sim, _ = create_simulator_from_scenario(
         'tests/testdata/scenarios/traininglang_scenario.yml'
@@ -493,15 +493,15 @@ def test_simulator_default_settings_defender_observation():
             assert not node.is_compromised() and not node.is_enabled_defense()
 
 def test_simulator_settings_defender_observation():
-    """Test MalSimulatorSettings only remember last step"""
+    """Test MalSimulatorSettings only show last steps in obs"""
 
-    settings_evict_attacker = MalSimulatorSettings(
-        remember_previous_steps_in_defender_obs=False
+    settings_dont_show_previous = MalSimulatorSettings(
+        cumulative_actions_in_defender_obs=False
     )
 
     sim, _ = create_simulator_from_scenario(
         'tests/testdata/scenarios/traininglang_scenario.yml',
-        sim_settings=settings_evict_attacker
+        sim_settings=settings_dont_show_previous
     )
     sim.reset()
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -487,7 +487,7 @@ def test_simulator_settings_defender_observation():
     """Test MalSimulatorSettings only show last steps in obs"""
 
     settings_dont_show_previous = MalSimulatorSettings(
-        cumulative_actions_in_defender_obs=False
+        cumulative_defender_obs=False
     )
 
     sim, _ = create_simulator_from_scenario(


### PR DESCRIPTION
Implement MalSimulatorSettings

A dataclass that can be created and given to `MalSimulator.__init__` when creating a MalSimulator. Contains default values, so if no MalSimulatorSettings object is given, things will still work as expected (see defaults below)

Currently supports two configuration options:

```python
    # uncompromise_untraversable_steps
    # - Uncompromise (evict attacker) from nodes/steps that are no longer
    #   traversable (often because a defense kicked in) if set to True
    # otherwise:
    # - Leave the node/step compromised even after it becomes untraversable
    uncompromise_untraversable_steps: bool = False

    # cumulative_actions_in_defender_obs
    # - Defender sees the status of the whole attack graph if set to True
    # otherwise:
    # - Defender only sees the status of nodes changed in the current step
    cumulative_defender_obs: bool = True
```

I need help with the naming (Andrei already helped a bit)
and whether it makes sense to have it as a class or not.

Also please check if the implementation of `cumulative_actions_in_defender_obs` looks sane.
I needed a way to hand the latest performed actions to the _observe_defender for it to work.