### PR TITLE
Implement is_observable rules in scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,4 @@ cython_debug/
 #.idea/
 
 # Allow .json/.yml files in testdata
-!tests/testdata/*/*
+!tests/testdata/**

--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,4 @@ cython_debug/
 #.idea/
 
 # Allow .json/.yml files in testdata
-!tests/testdata/*
+!tests/testdata/*/*

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ attacker_agent_class: 'BreadthFirstAttacker' | 'DepthFirstAttacker' | 'KeyboardA
 # For defender_agent_class, null and False are treated the same - no defender will be used in the simulation
 defender_agent_class: 'BreadthFirstAttacker' | 'DepthFirstAttacker' | 'KeyboardAgent' | null | False
 
-# Rewards for each attack step
+
+# Optionally add rewards for each attack step
 rewards:
-  <full name of attack step>: <reward>
   <full name of attack step>: <reward>
 
   # example:
   # Program 1:notPresent: 3
+  # Data A:read: 100
   ...
 
-# Add entry points to AttackGraph with attacker name and attack step full_names.
+
+# Optionally add entry points to AttackGraph with attacker name and attack step full_names.
 # NOTE: If attacker entry points defined in both model and scenario,
 #       the scenario overrides the ones in the model.
 attacker_entry_points:
@@ -43,6 +45,37 @@ attacker_entry_points:
   # example:
   # 'Attacker1':
   #   - 'Credentials:6:attemptCredentialsReuse'
+
+# Optionally add observability rules that are applied to AttackGrapNodes
+# to make only certain attack steps observable
+#
+# If 'observable_attack_steps' are set:
+# - Nodes that match any rule will be marked as observable
+# - Nodes that don't match any rules will be marked as non-observable
+# If 'observable_attack_steps' are not set:
+# - All nodes will be marked as observable
+#
+observable_attack_steps:
+  by_asset_type:
+    <asset_type>:
+      - <attack step name>
+  by_asset_name:
+    <asset_name>:
+      - <attack step name>
+
+  # Example:
+  #   by_asset_type:
+  #     Host:
+  #       - access
+  #       - authenticate
+  #     Data:
+  #       - read
+
+  #   by_asset_name:
+  #     User:3:
+  #       - phishing
+  #     ...
+
 ```
 
 Note: When defining attackers and entrypoints in a scenario, these override potential attackers in the model.

--- a/malsim/scenario.py
+++ b/malsim/scenario.py
@@ -163,7 +163,7 @@ def apply_scenario_observability_rules(
         # If no observability rules are given,
         # make all nodes in attagraph as observable
         for step in attack_graph.nodes:
-            step.extras['observable'] = True
+            step.extras['observable'] = 1
     else:
         # If observability rules are given
         # make the matching attack steps observable,
@@ -177,9 +177,9 @@ def apply_scenario_observability_rules(
             )
 
             if step.name in observable_attack_steps:
-                step.extras['observable'] = True
+                step.extras['observable'] = 1
             else:
-                step.extras['observable'] = False
+                step.extras['observable'] = 0
 
 
 def apply_scenario_attacker_entrypoints(

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -123,7 +123,9 @@ class MalSimulator(ParallelEnv):
         num_steps = len(self.attack_graph.nodes)
 
         observation = {
-            "is_observable": num_steps * [1],
+            # If no observability set for node, assume observable.
+            "is_observable": [step.extras.get('observable', 1)
+                           for step in self.attack_graph.nodes],
             "observed_state": num_steps * [-1],
             "remaining_ttc": num_steps * [0],
             "asset_type": [self._asset_type_to_index[step.asset.type]

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -86,6 +86,8 @@ def test_malsimulator_create_blank_observation_observability_given(
         # made into if statements
         if node.asset.type == 'Host' and node.name in ('access'):
             assert observable
+        elif node.asset.type == 'Host' and node.name in ('authenticate'):
+            assert observable
         elif node.asset.type == 'Data' and node.name in ('read'):
             assert observable
         elif node.asset.name == 'User:3' and node.name in ('phishing'):

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1,7 +1,7 @@
 """Test MalSimulator class"""
 import copy
 
-from maltoolbox.attackgraph import AttackGraph, Attacker, AttackGraphNode
+from maltoolbox.attackgraph import AttackGraph, Attacker
 from malsim.sims.mal_simulator import MalSimulator
 from malsim.scenario import load_scenario, create_simulator_from_scenario
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -132,3 +132,37 @@ def test_load_scenario_agent_class_error():
                 './testdata/scenarios/wrong_agent_classes_scenario.yml'
             )
         )
+
+
+def test_load_scenario_observability_given():
+    """Load a scenario with observability settings given and
+    make sure observability is applied correctly"""
+
+    # Load scenario with observability specifed
+    attack_graph, _ = load_scenario(
+        path_relative_to_tests(
+            './testdata/scenarios/simple_filtered_observability_scenario.yml')
+    )
+
+    # Make sure only attack steps of name fullAccess
+    # part of asset type Application are observable.
+    for node in attack_graph.nodes:
+        if node.asset.type == "Application" and node.name == "fullAccess":
+            assert node.extras['observable']
+        else:
+            assert not node.extras['observable']
+
+
+def test_load_scenario_observability_not_given():
+    """Load a scenario where no observability settings are given"""
+    # Load scenario with no observability specifed
+    attack_graph, _ = load_scenario(
+        path_relative_to_tests(
+            './testdata/scenarios/simple_scenario.yml'
+        )
+    )
+
+    # Make sure all attack steps are observable
+    # if no observability settings are given
+    for node in attack_graph.nodes:
+        assert node.extras['observable']

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -152,6 +152,10 @@ def test_load_scenario_observability_given():
     for node in attack_graph.nodes:
         if node.asset.type == "Application" and node.name == "fullAccess":
             assert node.extras['observable']
+        elif node.asset.type == "Application" and node.name == "supplyChainAuditing":
+            assert node.extras['observable']
+        elif node.asset.name == "Identity:8" and node.name == "assume":
+            assert node.extras['observable']
         else:
             assert not node.extras['observable']
 

--- a/tests/testdata/scenarios/simple_filtered_observability_scenario.yml
+++ b/tests/testdata/scenarios/simple_filtered_observability_scenario.yml
@@ -24,12 +24,13 @@ attacker_entry_points:
 
 # Optional way to make only certain attack steps observable
 # If observable_attack_steps are set, all attack steps not
-# matching these rules will have observability set to False.
+# matching these rules will have observability set to 0.
 observable_attack_steps:
   by_asset_type:
     Application:
       - fullAccess
+      - supplyChainAuditing
 
   by_asset_name:
-    OS App:
-      - fullAccess
+    Identity:8:
+      - assume

--- a/tests/testdata/scenarios/simple_filtered_observability_scenario.yml
+++ b/tests/testdata/scenarios/simple_filtered_observability_scenario.yml
@@ -23,6 +23,13 @@ attacker_entry_points:
     - 'Credentials:6:attemptCredentialsReuse'
 
 # Optional way to make only certain attack steps observable
-observable_attack_step_names:
-  Application:
-    - fullAccess
+# If observable_attack_steps are set, all attack steps not
+# matching these rules will have observability set to False.
+observable_attack_steps:
+  by_asset_type:
+    Application:
+      - fullAccess
+
+  by_asset_name:
+    OS App:
+      - fullAccess

--- a/tests/testdata/scenarios/simple_filtered_observability_scenario.yml
+++ b/tests/testdata/scenarios/simple_filtered_observability_scenario.yml
@@ -1,0 +1,28 @@
+lang_file: ../langs/org.mal-lang.coreLang-1.0.0.mar
+model_file: ../models/simple_test_model.yml
+
+attacker_agent_class: 'BreadthFirstAttacker'
+defender_agent_class: 'KeyboardAgent'
+
+# Rewards for each attack step
+rewards:
+  OS App:notPresent: 2
+  OS App:supplyChainAuditing: 7
+  Program 1:notPresent: 3
+  Program 1:supplyChainAuditing: 7
+  SoftwareVulnerability:4:notPresent: 4
+  Data:5:notPresent: 1
+  Credentials:6:notPhishable: 7
+  Identity:11:notPresent: 3.5
+  Identity:8:assume: 50
+
+# Add entry points to AttackGraph with attacker names
+# and attack step full_names
+attacker_entry_points:
+  'Attacker1':
+    - 'Credentials:6:attemptCredentialsReuse'
+
+# Optional way to make only certain attack steps observable
+observable_attack_step_names:
+  Application:
+    - fullAccess

--- a/tests/testdata/scenarios/traininglang_observability_scenario.yml
+++ b/tests/testdata/scenarios/traininglang_observability_scenario.yml
@@ -27,6 +27,7 @@ observable_attack_steps:
   by_asset_type:
     Host:
       - access
+      - authenticate
     Data:
       - read
 

--- a/tests/testdata/scenarios/traininglang_observability_scenario.yml
+++ b/tests/testdata/scenarios/traininglang_observability_scenario.yml
@@ -1,0 +1,35 @@
+lang_file: ../langs/org.mal-lang.trainingLang-1.0.0.mar
+model_file: ../models/traininglang_model.yml
+
+# Rewards for each attack step
+rewards:
+  Host:0:notPresent: 2
+  Host:0:access: 4
+  Host:1:notPresent: 7
+  Host:1:access: 5
+  Data:2:notPresent: 8
+  Data:2:read: 5
+  Data:2:modify: 10
+
+# The possible entry points
+attacker_entry_points:
+  'Attacker1':
+    - 'User:3:phishing'
+    - 'Host:0:connect'
+
+attacker_agent_class: 'BreadthFirstAttacker'
+defender_agent_class: 'KeyboardAgent'
+
+# Optional way to make only certain attack steps observable
+# If observable_attack_steps are set, all attack steps not
+# matching these rules will have observability set to False.
+observable_attack_steps:
+  by_asset_type:
+    Host:
+      - access
+    Data:
+      - read
+
+  by_asset_name:
+    User:3:
+      - phishing


### PR DESCRIPTION
Gives the option to add observability rules into scenario configs.

- User can now specify observability rules for certain attack steps either by
  - asset name + attack step name
  - asset type + attack step name
 
Scenario loading:
- The observability rules are applied when loading a scenario, this updates each node.extras['observable'] to either 1 or 0
  - 1 if the node follows one of the rules given, otherwise 0 
- If no rules are given in the scenario config file, all steps/nodes are marked as observable  = 1.

Observability rules are validated to make sure they contain valid asset types/names and and attack steps.

MalSimulator:
- The 'is_observable' in the observation given from the simulator will contain 1 or 0 depending on if rule was created in scenario config file. (previously it was always 1)

