### PR TITLE
False positives negatives rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ actionable_steps:
   #       - phishing
   #     ...
 
+
+# Optionally add false positive/negative rates to observations.
+#
+# False positive/negative `rate` is a number between 0.0 and 1.0.
+#  - A false positive rate of x for means that an inactive attack step
+#    will be observed as active at a rate of x in each observation
+#  - A false negative rate of x for means that an active attack step
+#    will be observed as inactive at a rate of x in each observation
+# Default false positive/negative rate is 0, which is assumed if none are given.
+
+# Applies false positive rates per attack step (default 0)
+false_positive_rates:
+  <attack step full name>: <rate>
+
+# Applies false negative rates per attack step (default 0)
+false_negative_rates:
+  <attack step full name>: <rate>
+
 ```
 
 ### Loading a scenario from a python script

--- a/README.md
+++ b/README.md
@@ -125,11 +125,21 @@ actionable_steps:
 
 # Applies false positive rates per attack step (default 0)
 false_positive_rates:
-  <attack step full name>: <rate>
+  by_asset_type:
+    <asset_type>:
+      <step name>: rate (float)
+  by_asset_name:
+    <asset_name>:
+      <step name>: rate (float)
 
 # Applies false negative rates per attack step (default 0)
 false_negative_rates:
-  <attack step full name>: <rate>
+  by_asset_type:
+    <asset_type>:
+      <step name>: rate (float)
+  by_asset_name:
+    <asset_name>:
+      <step name>: rate (float)
 
 ```
 

--- a/malsim/scenario.py
+++ b/malsim/scenario.py
@@ -108,7 +108,7 @@ def apply_scenario_rewards(
         node.extras['reward'] = reward
 
 
-def _validate_scenario_property_rules(
+def _validate_scenario_node_property_config(
         graph: AttackGraph, rules: dict):
     """Verify that observability/actionability rules in a scenario contains
     only valid assets, asset types and step names"""
@@ -179,7 +179,7 @@ def apply_scenario_node_property_rules(
              and/or `by_asset_type`
     """
 
-    _validate_scenario_property_rules(attack_graph, rules)
+    _validate_scenario_node_property_config(attack_graph, rules)
 
     if not rules:
         # If no rules are given, make all steps as observable/actionable
@@ -210,7 +210,7 @@ def apply_scenario_node_property_rules(
 def apply_scenario_node_property_values(
         attack_graph: AttackGraph, node_prop: str, values: dict,
 ):
-    """Apply node property rules from scenario configuration.
+    """Apply node property values from scenario configuration.
 
     Sets node.extras[node_prop] to value defined by rules for nodes
     that match rule in the AttackGraph. Values defined per asset has
@@ -223,7 +223,7 @@ def apply_scenario_node_property_values(
               and/or `by_asset_type`
     """
 
-    _validate_scenario_property_rules(attack_graph, values)
+    _validate_scenario_node_property_config(attack_graph, values)
 
     if not values:
         # If no rules defined, do not set the values at all

--- a/malsim/scenario.py
+++ b/malsim/scenario.py
@@ -56,8 +56,6 @@ allowed_fields = required_fields + [
     'rewards',
     'observable_steps',
     'actionable_steps',
-    'attacker_entry_points',
-    'observable_attack_steps',
     'false_positive_rates',
     'false_negative_rates',
 ]

--- a/malsim/scenario.py
+++ b/malsim/scenario.py
@@ -12,7 +12,7 @@ A scenario is a combination of:
 """
 
 import os
-from typing import Optional, Any
+from typing import Any
 
 import yaml
 

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -273,3 +273,36 @@ def test_apply_scenario_observability_faulty():
             'observable',
             {'by_asset_name': {'OS App': ['nonExistingAttackStep']}}
         )
+
+
+def test_load_scenario_false_positive_negative_rate():
+    """Load a scenario with observability settings given and
+    make sure observability is applied correctly"""
+
+    # Load scenario with observability specifed
+    attack_graph, _ = load_scenario(
+        path_relative_to_tests(
+            './testdata/scenarios/traininglang_fp_fn_scenario.yml')
+    )
+
+    # Defined in scenario file
+    host_0_access_fp_rate = 0.2
+    host_1_access_fp_rate = 0.3
+    host_0_access_fn_rate = 0.4
+    host_1_access_fn_rate = 0.5
+    user_3_compromise_fn_rate = 1.0
+
+    for node in attack_graph.nodes.values():
+        if node.full_name == "Host:0:access":
+            assert node.extras['false_positive_rate'] == host_0_access_fp_rate
+            assert node.extras['false_negative_rate'] == host_0_access_fn_rate
+        elif node.full_name == "Host:1:access":
+            assert node.extras['false_positive_rate'] == host_1_access_fp_rate
+            assert node.extras['false_negative_rate'] == host_1_access_fn_rate
+        elif node.full_name == "User:3:compromise":
+            assert 'false_positive_rate' not in node.extras
+            assert node.extras['false_negative_rate'] \
+                == user_3_compromise_fn_rate
+        else:
+            assert 'false_positive_rate' not in node.extras
+            assert 'false_negative_rate' not in node.extras

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -5,6 +5,7 @@ import pytest
 
 from malsim.scenario import (
     apply_scenario_node_property_rules,
+    apply_scenario_node_property_values,
     load_scenario
 )
 from malsim.agents import PassiveAgent, BreadthFirstAttacker

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -294,16 +294,75 @@ def test_load_scenario_false_positive_negative_rate():
     user_3_compromise_fn_rate = 1.0
 
     for node in attack_graph.nodes.values():
+
         if node.full_name == "Host:0:access":
+            # According to scenario file
             assert node.extras['false_positive_rate'] == host_0_access_fp_rate
             assert node.extras['false_negative_rate'] == host_0_access_fn_rate
+
         elif node.full_name == "Host:1:access":
+            # According to scenario file
             assert node.extras['false_positive_rate'] == host_1_access_fp_rate
             assert node.extras['false_negative_rate'] == host_1_access_fn_rate
+
         elif node.full_name == "User:3:compromise":
+            # According to scenario file
             assert 'false_positive_rate' not in node.extras
             assert node.extras['false_negative_rate'] \
                 == user_3_compromise_fn_rate
+
         else:
+            # If no rules - don't set fpr/fnr
             assert 'false_positive_rate' not in node.extras
+            assert 'false_negative_rate' not in node.extras
+
+def test_apply_scenario_fpr_fnr():
+    """Try different cases for false positives/negatives rates"""
+
+    # Load scenario with no specified
+    attack_graph, _ = load_scenario(
+        path_relative_to_tests(
+            'testdata/scenarios/simple_scenario.yml')
+    )
+
+    property_values = {
+        'by_asset_type': {
+            'Data': {
+                'read': 0.5,
+                'write': 0.6,
+                'delete': 0.7
+            },
+            'Application': {
+                'fullAccess': 0.8,
+                'read': 1.0
+            }
+        },
+        'by_asset_name': {
+            'OS App': {
+                'read': 0.9 # Has precedence
+            }
+        }
+    }
+
+    # Apply false negative rate rules
+    apply_scenario_node_property_values(
+        attack_graph, 'false_negative_rate', property_values
+    )
+
+    # Make sure all attack steps are observable
+    # if no observability settings are given
+    for node in attack_graph.nodes.values():
+        if node.lg_attack_step.asset.name == 'Data' and node.name == 'read':
+            assert node.extras['false_negative_rate'] == 0.5
+        elif node.lg_attack_step.asset.name == 'Data' and node.name == 'write':
+            assert node.extras['false_negative_rate'] == 0.6
+        elif node.lg_attack_step.asset.name == 'Data' and node.name == 'delete':
+            assert node.extras['false_negative_rate'] == 0.7
+        elif node.model_asset.name == 'OS App' and node.name == 'read':
+            assert node.extras['false_negative_rate'] == 0.9
+        elif node.lg_attack_step.asset.name == 'Application' and node.name == 'read':
+            assert node.extras['false_negative_rate'] == 1.0
+        elif node.lg_attack_step.asset.name == 'Application' and node.name == 'fullAccess':
+            assert node.extras['false_negative_rate'] == 0.8
+        else:
             assert 'false_negative_rate' not in node.extras

--- a/tests/testdata/scenarios/traininglang_fp_fn_scenario.yml
+++ b/tests/testdata/scenarios/traininglang_fp_fn_scenario.yml
@@ -1,0 +1,34 @@
+lang_file: ../langs/org.mal-lang.trainingLang-1.0.0.mar
+model_file: ../models/traininglang_model.yml
+
+# Rewards for each attack step
+rewards:
+  Host:0:notPresent: 2
+  Host:0:access: 4
+  Host:1:notPresent: 7
+  Host:1:access: 5
+  Data:2:notPresent: 8
+  Data:2:read: 5
+  Data:2:modify: 10
+
+# Specific fpr/fnr for some specific steps
+false_positive_rates:
+  'Host:0:access': 0.2
+  'Host:1:access': 0.3
+
+false_negative_rates:
+  'Host:0:access': 0.4
+  'Host:1:access': 0.5
+  'User:3:compromise': 1.0 # Always false negative
+
+
+agents:
+  Attacker1:
+    type: attacker
+    agent_class: 'BreadthFirstAttacker'
+    entry_points:
+      - 'User:3:phishing'
+      - 'Host:0:connect'
+  defender:
+    type: defender
+    agent_class: 'KeyboardAgent'

--- a/tests/testdata/scenarios/traininglang_fp_fn_scenario.yml
+++ b/tests/testdata/scenarios/traininglang_fp_fn_scenario.yml
@@ -13,13 +13,20 @@ rewards:
 
 # Specific fpr/fnr for some specific steps
 false_positive_rates:
-  'Host:0:access': 0.2
-  'Host:1:access': 0.3
+  by_asset_name:
+    Host:0:
+      access: 0.2
+    Host:1:
+      access: 0.3
 
 false_negative_rates:
-  'Host:0:access': 0.4
-  'Host:1:access': 0.5
-  'User:3:compromise': 1.0 # Always false negative
+  by_asset_name:
+    Host:0:
+      access: 0.4
+    Host:1:
+      access: 0.5
+    User:3:
+      compromise: 1.0
 
 
 agents:


### PR DESCRIPTION
User can specify false positive/negative rate for specific attack graph nodes
The are applied by scenario on the attack graph into node.extras field.

They do not affect simulation run, but are supposed to be used by wrappers that build observations.

NOTE: ignore previous comments here because that was regarding the old serialized environment