### PR TITLE
Restructure observed states in simulator

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -563,27 +563,28 @@ class MalSimulator(ParallelEnv):
             for agent in self.agents:
                 if self.agents_dict[agent]["type"] == "attacker":
 
-                    attacker_index = self.agents_dict[agent]["attacker"]
-                    attacker = self.attack_graph.attackers[attacker_index]
-                    node_index = self._id_to_index[node.id]
+                    if self.sim_settings.uncompromise_untraversable_steps:
+                        attacker_index = self.agents_dict[agent]["attacker"]
+                        attacker = self.attack_graph.attackers[attacker_index]
+                        node_index = self._id_to_index[node.id]
 
-                    logger.info(
-                        'Remove untraversable node from attacker '
-                        '"%s": "%s"(%d)',
-                            agent,
-                            node.full_name,
-                            node.id
-                    )
+                        logger.info(
+                            'Remove untraversable node from attacker '
+                            '"%s": "%s"(%d)',
+                                agent,
+                                node.full_name,
+                                node.id
+                        )
 
-                    agent_observation = self._agent_observations[agent]
-                    node_obs = agent_observation['observed_state'][node_index]
+                        agent_observation = self._agent_observations[agent]
+                        node_obs = agent_observation['observed_state'][node_index]
 
-                    if node.type in ('and', 'or') and \
-                       node_obs == 1 and \
-                       node not in attacker.entry_points:
+                        if node.type in ('and', 'or') and \
+                        node_obs == 1 and \
+                        node not in attacker.entry_points:
 
-                        attacker.undo_compromise(node)
-                        agent_observation['observed_state'][node_index] = 0
+                            attacker.undo_compromise(node)
+                            agent_observation['observed_state'][node_index] = 0
                     try:
                         self.action_surfaces[agent].remove(node)
                     except ValueError:

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -805,11 +805,8 @@ class MalSimulator(ParallelEnv):
         ):
         """Disable nodes for each attacker agent
 
-        - For each compromised attack step:
-            - Uncompromise the node, disable its observed_state
-              and remove the rewards if sim_settings has the
-              uncompromise_untraversable_steps parameter enabled.
-            - Remove from each attackers action_surface.
+        For each compromised attack step uncompromise the node, disable its
+        observed_state, and remove the rewards.
         """
 
         for attacker_agent in self.get_attacker_agents():

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -503,11 +503,12 @@ class MalSimulator(ParallelEnv):
 
     def _attacker_step(self, agent, attack_step):
         actions = []
-        attacker = self.attack_graph.attackers[self.agents_dict[agent]["attacker"]]
+        attacker_index = self.agents_dict[agent]["attacker"]
+        attacker = self.attack_graph.attackers[attacker_index]
         attack_step_node = self.attack_graph.get_node_by_id(
-            self._index_to_id[attack_step]
-        )
-        logger.info(
+            self._index_to_id[attack_step])
+
+        logger.debug(
             'Attacker agent "%s" stepping through "%s"(%d).',
             agent,
             attack_step_node.full_name,
@@ -528,6 +529,7 @@ class MalSimulator(ParallelEnv):
                         self.action_surfaces[agent],
                         [attack_step_node]
                     )
+            # TODO: should below line be part of the inner if-stmt?
             actions.append(attack_step)
         else:
             logger.warning(

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -469,15 +469,21 @@ class MalSimulator(ParallelEnv):
             'Register attacker "%s" agent with '
             "attacker index %d.", agent_name, attacker
         )
+        assert agent_name not in self.agents_dict, \
+                f"Duplicate attacker agent named {agent_name} not allowed"
+
         self.possible_agents.append(agent_name)
-        self.agents_dict[agent_name] = {"type": "attacker",
-            "attacker": attacker}
+        self.agents_dict[agent_name] = {
+            "type": "attacker",
+            "attacker": attacker
+        }
 
     def register_defender(self, agent_name):
-        # Defenders are run first so that the defenses prevent the attacker
-        # appropriately in case the attacker selects an attack step that the
-        # defender safeguards against in the same step.
+        """Add defender agent to the simulator"""
         logger.info('Register defender "%s" agent.', agent_name)
+        assert agent_name not in self.agents_dict, \
+                f"Duplicate defender agent named {agent_name} not allowed"
+
         self.possible_agents.insert(0, agent_name)
         self.agents_dict[agent_name] = {"type": "defender"}
 

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -630,7 +630,8 @@ class MalSimulator(ParallelEnv):
         actions.append(defense_step_index)
 
         # Remove defense from all defender agents' action surfaces since it is
-        # already enabled.
+        # already enabled. And remove all of the prevented attack steps from
+        # the attackers' action surfaces.
         for agent_el in self.agents:
             if self.agents_dict[agent_el]["type"] == "defender":
                 try:
@@ -642,6 +643,18 @@ class MalSimulator(ParallelEnv):
                     # may have not been present to save one extra
                     # lookup.
                     pass
+            elif self.agents_dict[agent_el]["type"] == "attacker":
+                for attack_step in prevented_attack_steps:
+                    try:
+                        # Node is no longer part of attacker action surface
+                        self.agents_dict[agent_el]\
+                            ["action_surface"].remove(attack_step)
+                    except ValueError:
+                        # Optimization: the attacker is told to remove
+                        # the node from its attack surface even if it may
+                        # have not been present to save one extra lookup.
+                        pass
+
 
         return actions, prevented_attack_steps
 
@@ -821,16 +834,6 @@ class MalSimulator(ParallelEnv):
                     step_index = self._id_to_index[unviable_node.id]
                     agent_obs = self.agents_dict[attacker_agent]["observation"]
                     agent_obs['observed_state'][step_index] = 0
-
-                try:
-                    # Node is no longer part of attacker action surface
-                    self.agents_dict[attacker_agent]\
-                        ["action_surface"].remove(unviable_node)
-                except ValueError:
-                    # Optimization: the attacker is told to remove
-                    # the node from its attack surface even if it may
-                    # have not been present to save one extra lookup.
-                    pass
 
 
     def _observe_and_reward(

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -79,11 +79,12 @@ class MalSimulator(ParallelEnv):
         logger.info("Create Mal Simulator.")
         self.lang_graph = lang_graph
         self.model = model
+
         apriori.calculate_viability_and_necessity(attack_graph)
         if prune_unviable_unnecessary:
             apriori.prune_unviable_and_unnecessary_nodes(attack_graph)
-        self.attack_graph = attack_graph
 
+        self.attack_graph = attack_graph
         self.sim_settings = sim_settings
         self.max_iter = max_iter
 
@@ -98,7 +99,7 @@ class MalSimulator(ParallelEnv):
     def __call__(self):
         return self
 
-    def create_blank_observation(self):
+    def create_blank_observation(self, default_obs_state=-1):
         # For now, an `object` is an attack step
         num_steps = len(self.attack_graph.nodes)
 
@@ -106,7 +107,7 @@ class MalSimulator(ParallelEnv):
             # If no observability set for node, assume observable.
             "is_observable": [step.extras.get('observable', 1)
                            for step in self.attack_graph.nodes],
-            "observed_state": num_steps * [-1],
+            "observed_state": num_steps * [default_obs_state],
             "remaining_ttc": num_steps * [0],
             "asset_type": [self._asset_type_to_index[step.asset.type]
                            for step in self.attack_graph.nodes],

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -704,11 +704,10 @@ class MalSimulator(ParallelEnv):
         obs_state = self.agents_dict[defender_agent]["observation"]\
             ["observed_state"]
 
-        # TODO: need to handle defense steps disabling attack steps
         if not self.sim_settings.cumulative_defender_obs:
-            # View all states as unknown
-            # TODO: Should they be disabled (0) instead?
-            obs_state.fill(-1)
+            # Clear the state if we do not it to accumulate observations over
+            # time.
+            obs_state.fill(0)
 
         # Only show the latest steps taken
         for _, actions in performed_actions.items():

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -696,20 +696,26 @@ class MalSimulator(ParallelEnv):
                         attacker.undo_compromise(defended_child)
 
     def _observe_defender(
-            self, defender_agent, performed_actions, observation):
-        # TODO We should probably create a separate blank observation for the
-        # defenders and just update that with the defense action taken so that
-        # we do not have to go through the list of nodes every time. In case
-        # we have multiple defenders
+            self,
+            defender_agent,
+            performed_actions: dict[str, list[int]]
+        ):
+
+        obs_state = self._agent_observations[defender_agent]["observed_state"]
 
         if self.sim_settings.cumulative_defender_obs:
-            # Show all active steps as they really are
-            observation["observed_state"] = self._true_state
+            # Add the latest performed actions to the observed state
+            # TODO: need to handle defense steps disabling attack steps
+            pass
         else:
-            # Only show the latest steps taken
-            for action in performed_actions:
-                observation["observed_state"][action] = 1
+            # View all states as unknown
+            # TODO: Should they be disabled (0) instead?
+            obs_state.fill(-1)
 
+        # Only show the latest steps taken
+        for _, actions in performed_actions.items():
+            for action in actions:
+                obs_state[action] = 1
 
     def _observe_and_reward(self, performed_actions: list[int]):
         observations = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ def traininglang_lang_graph():
 def traininglang_model(traininglang_lang_graph):
     """Fixture that generates a model for tests
 
-    Uses coreLang specification (fixture) to create and return a
+    Uses trainingLang specification (fixture) to create and return a
     Model object with no assets or associations
     """
     # Init LanguageClassesFactory

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,26 @@ def corelang_lang_graph():
 
 
 @pytest.fixture
+def traininglang_lang_graph():
+    """Fixture that returns the trainingLang language specification as dict"""
+    mar_file_path = path_testdata("langs/org.mal-lang.trainingLang-1.0.0.mar")
+    return LanguageGraph.from_mar_archive(mar_file_path)
+
+
+@pytest.fixture
+def traininglang_model(traininglang_lang_graph):
+    """Fixture that generates a model for tests
+
+    Uses coreLang specification (fixture) to create and return a
+    Model object with no assets or associations
+    """
+    # Init LanguageClassesFactory
+    traininglang_model_file = 'tests/testdata/models/traininglang_model.yml'
+    lang_classes_factory = LanguageClassesFactory(traininglang_lang_graph)
+    return Model.load_from_file(traininglang_model_file, lang_classes_factory)
+
+
+@pytest.fixture
 def model(corelang_lang_graph):
     """Fixture that generates a model for tests
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -188,7 +188,14 @@ def test_malsimulator_reset(corelang_lang_graph, model):
     # Make sure agent was added (and not removed)
     assert agent_name in sim.agents
     # Make sure the attack graph is not the same object but identical
-    assert attack_graph_before != attack_graph_after
+    assert id(attack_graph_before) != id(attack_graph_after)
+
+    for node in attack_graph_after.nodes:
+        # Entry points are added to the nodes after backup is created
+        # So they have to be removed for the graphs to be compared as identical
+        if 'entrypoint' in node.extras:
+            del node.extras['entrypoint']
+
     assert attack_graph_before._to_dict() == attack_graph_after._to_dict()
 
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -458,7 +458,8 @@ def test_malsimulator_step(corelang_lang_graph, model):
     agent_name = "attacker1"
     attacker_id = attack_graph.attackers[0].id
     sim.register_attacker(agent_name, attacker_id)
-    assert not sim.action_surfaces
+    assert agent_name in sim.agents_dict
+    assert not sim.agents_dict[agent_name]['action_surface']
 
     obs, infos = sim.reset()
 
@@ -469,7 +470,8 @@ def test_malsimulator_step(corelang_lang_graph, model):
     actions = {agent_name: (action, step_index)}
     observations, rewards, terminations, truncations, infos = sim.step(actions)
     assert len(observations[agent_name]['observed_state']) == len(attack_graph.nodes)
-    assert agent_name in sim.action_surfaces
+    assert agent_name in sim.agents_dict
+    assert sim.agents_dict[agent_name]['action_surface']
 
     # Make sure 'OS App:attemptUseVulnerability' is observed and set to 1 (active)
     assert observations[agent_name]['observed_state'][step_index] == 1

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -961,7 +961,7 @@ def test_simulator_settings_defender_observation():
         if node == user_3_compromise:
             assert state == 1 # Last performed step known active state
         else:
-            assert state == -1 # All others unknown
+            assert state == 0 # All others inactive
 
     # Now let the defender defend, and the attacker waits
     actions = {
@@ -979,4 +979,4 @@ def test_simulator_settings_defender_observation():
         if node == user_3_compromise_defense:
             assert state == 1 # Last performed step known active state
         else:
-            assert state == -1 # All others unknown
+            assert state == 0 # All others inactive

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -211,6 +211,38 @@ def test_malsimulator_register_defender(corelang_lang_graph, model):
     assert agent_name in sim.agents_dict
 
 
+def test_simulator_initialize_agents():
+    """Test _initialize_agents"""
+
+    sim, _ = create_simulator_from_scenario(
+        'tests/testdata/scenarios/simple_scenario.yml',
+    )
+    sim.reset()
+    agents = sim._initialize_agents()
+    assert set(agents.keys()) == {'defender', 'attacker'}
+
+    for node in sim.attack_graph.nodes:
+        node_index = sim._id_to_index[node.id]
+        if node.is_enabled_defense():
+            assert node_index in agents['defender']
+        elif node.is_compromised():
+            assert node_index in agents['attacker']
+        else:
+            assert node_index not in agents['defender']
+            assert node_index not in agents['attacker']
+
+
+def test_get_agents():
+    """Test get_attacker_agents and get_defender_agents"""
+
+    sim, _ = create_simulator_from_scenario(
+        'tests/testdata/scenarios/simple_scenario.yml',
+    )
+    sim.reset()
+    sim.get_attacker_agents() == ['attacker']
+    sim.get_defender_agents() == ['defender']
+
+
 def test_malsimulator_attacker_step(corelang_lang_graph, model):
     attack_graph = AttackGraph(corelang_lang_graph, model)
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -1,7 +1,6 @@
 """Test MalSimulator class"""
-import copy
 
-from maltoolbox.attackgraph import AttackGraph, Attacker, AttackGraphNode
+from maltoolbox.attackgraph import AttackGraph, Attacker
 from malsim.sims.mal_simulator import MalSimulator
 from malsim.scenario import load_scenario, create_simulator_from_scenario
 from malsim.sims import MalSimulatorSettings

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -643,6 +643,135 @@ def test_malsimulator_observe_and_reward_attacker_defender():
     assert rew[defender_name] == -rew[attacker_name] - reward_host_0_not_present
 
 
+def test_malsimulator_observe_and_reward_uncompromise_untraversable():
+    """Run attacker and defender actions and make sure
+    rewards and observation states are updated correctly"""
+
+    def verify_attacker_obs_state(
+            obs_state,
+            expected_reached,
+            expected_children_of_reached
+        ):
+        """Make sure obs state looks as expected"""
+        for index, state in enumerate(obs_state):
+            node_id = sim._index_to_id[index]
+            node = sim.attack_graph.get_node_by_id(node_id)
+            if state == 1:
+                assert node_id in expected_reached
+            elif state == 0:
+                assert node_id in expected_children_of_reached or \
+                       (node_id in expected_reached and not node.is_viable)
+            else:
+                assert state == -1
+
+    sim, _ = create_simulator_from_scenario(
+        'tests/testdata/scenarios/traininglang_scenario.yml',
+        sim_settings=MalSimulatorSettings(
+            uncompromise_untraversable_steps=True
+        )
+    )
+    sim.reset()
+
+    attacker = sim.attack_graph.attackers[0]
+    attacker_name = "attacker"
+    defender_name = "defender"
+    attacker_reached_steps = [n.id for n in attacker.entry_points]
+    attacker_reached_step_children = []
+    for reached in attacker.entry_points:
+        attacker_reached_step_children.extend(
+            [n.id for n in reached.children])
+
+    # Prepare nodes that will be stepped through in order
+    user_3_compromise = sim.attack_graph\
+        .get_node_by_full_name("User:3:compromise")
+    host_0_authenticate = sim.attack_graph\
+        .get_node_by_full_name("Host:0:authenticate")
+    host_0_access = sim.attack_graph\
+        .get_node_by_full_name("Host:0:access")
+    host_0_notPresent = sim.attack_graph\
+        .get_node_by_full_name("Host:0:notPresent")
+    data_2_read = sim.attack_graph\
+        .get_node_by_full_name("Data:2:read")
+
+    # Step with attacker action
+    obs, rew, _, _, _ = sim.step({
+            defender_name: (0, None),
+            attacker_name: (1, sim._id_to_index[user_3_compromise.id])
+        }
+    )
+
+    # Verify obs state
+    attacker_reached_steps.append(user_3_compromise.id)
+    attacker_reached_step_children.extend(
+        [n.id for n in user_3_compromise.children])
+    verify_attacker_obs_state(
+        obs[attacker_name]['observed_state'],
+        attacker_reached_steps,
+        attacker_reached_step_children)
+
+    # Verify rewards
+    assert rew[defender_name] == 0
+    assert rew[attacker_name] == 0
+
+    # Step with attacker again
+    obs, rew, _, _, _ = sim.step({
+        defender_name: (0, None),
+        attacker_name: (1, sim._id_to_index[host_0_authenticate.id])
+    })
+
+    # Verify obs state
+    attacker_reached_steps.append(host_0_authenticate.id)
+    attacker_reached_step_children.extend(
+        [n.id for n in host_0_authenticate.children])
+    verify_attacker_obs_state(
+        obs[attacker_name]['observed_state'],
+        attacker_reached_steps,
+        attacker_reached_step_children)
+
+    # Verify rewards
+    assert rew[defender_name] == 0
+    assert rew[attacker_name] == 0
+
+    # Step attacker again
+    obs, rew, _, _, _ = sim.step({
+        defender_name: (0, None),
+        attacker_name: (1, sim._id_to_index[host_0_access.id])
+    })
+
+    # Verify obs state
+    attacker_reached_steps.append(host_0_access.id)
+    attacker_reached_step_children.extend(
+        [n.id for n in host_0_access.children])
+    verify_attacker_obs_state(
+        obs[attacker_name]['observed_state'],
+        attacker_reached_steps,
+        attacker_reached_step_children)
+
+    reward_host_0_access = 4
+    # Verify rewards
+    assert rew[attacker_name] == reward_host_0_access
+    assert rew[defender_name] == -rew[attacker_name]
+
+    # Step defender and attacker
+    # Attacker wont be able to traverse Data:2:read since
+    # Host:0:notPresent is activated before
+    obs, rew, _, _, _ = sim.step({
+        defender_name: (1, sim._id_to_index[host_0_notPresent.id]),
+        attacker_name: (1, sim._id_to_index[data_2_read.id])
+    })
+
+    # Attacker obs state should look the same as before
+    verify_attacker_obs_state(
+        obs[attacker_name]['observed_state'],
+        attacker_reached_steps,
+        attacker_reached_step_children)
+
+    # Verify rewards
+    reward_host_0_not_present = 2
+    assert rew[attacker_name] == 0  # no reward anymore
+    assert rew[defender_name] == -reward_host_0_not_present
+
+
 def test_simulator_settings_evict_attacker():
     """Test MalSimulatorSettings when it should evict attacker
     from untraversable node"""


### PR DESCRIPTION
For performance and structural reasons we want to change how states are built in MalSimulator.
Currently, observations (observed states) are built up every time. This is costly, especially for the attacker as they enable more and more attack steps which leads to us looping over more and more nodes in each step of the simulator.

The proposed solution is to instead build up the state in the beginning of the simulation and then add on the delta (actions) performed in each step to each agents observed state depending on their type., This definitely gives a performance boost, and will improve training time as well (how much?).

I have marked many questions with TODO in the code that need to be sorted out before merge.

We also need more tests and review to make sure no behavior has changed in the Simulator due to this PR.

