### PR TITLE
Add Instance Model to Observation

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -194,11 +194,14 @@ class MalSimulator(ParallelEnv):
         """
         obs_str = '\nAttack Graph Steps\n'
 
-        str_format = "{:<5} {:<80} {:<6} {:<5} {:<5} {:<5} {:<5} {:<}\n"
+        str_format = "{:<5} {:<80} {:<6} {:<5} {:<5} {:<30} {:<8} {:<}\n"
         header_entry = [
-            "Entry", "Name", "Is_Obs", "State", "RTTC", "Type", "Id", "Step"]
+            "Entry", "Name", "Is_Obs", "State", "RTTC", "Asset Type(Index)", "Asset Id", "Step"]
         entries = []
         for entry in range(0, len(observation["observed_state"])):
+            asset_type_index = observation["asset_type"][entry]
+            asset_type_str = self._index_to_asset_type[asset_type_index ] + \
+                '(' + str(asset_type_index) + ')'
             entries.append(
                 [
                     entry,
@@ -206,7 +209,7 @@ class MalSimulator(ParallelEnv):
                     observation["is_observable"][entry],
                     observation["observed_state"][entry],
                     observation["remaining_ttc"][entry],
-                    observation["asset_type"][entry],
+                    asset_type_str,
                     observation["asset_id"][entry],
                     observation["step_name"][entry],
                 ]

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -156,7 +156,11 @@ class MalSimulator(ParallelEnv):
             for left_asset in left_field:
                 for right_asset in right_field:
                     observation["model_edges_ids"].append(
-                        [left_asset.id, right_asset.id])
+                        [
+                            self._model_asset_id_to_index[left_asset.id],
+                            self._model_asset_id_to_index[right_asset.id]
+                        ]
+                    )
                     observation["model_edges_type"].append(
                         self._model_assoc_type_to_index[
                             self._get_association_full_name(assoc)])
@@ -245,20 +249,26 @@ class MalSimulator(ParallelEnv):
         obs_str += "\nInstance Model Edges:\n"
         str_format = "{:<5} {:<40} {:<40} {:<}\n"
         header_entry = [
-            "Entry", "Left Asset(Id)", "Right Asset(Id)", "Type(Index)"]
+            "Entry",
+            "Left Asset(Id/Index)",
+            "Right Asset(Id/Index)",
+            "Type(Index)"
+        ]
         entries = []
         for entry in range(0, len(observation["model_edges_ids"])):
             assoc_type_str = self._index_to_model_assoc_type[
                 observation["model_edges_type"][entry]] + \
                     '(' + str(observation["model_edges_type"][entry]) + ')'
-            left_asset_id = int(observation["model_edges_ids"][entry][0])
-            right_asset_id = int(observation["model_edges_ids"][entry][1])
+            left_asset_index = int(observation["model_edges_ids"][entry][0])
+            right_asset_index = int(observation["model_edges_ids"][entry][1])
+            left_asset_id = self._index_to_model_asset_id[left_asset_index]
+            right_asset_id = self._index_to_model_asset_id[right_asset_index]
             left_asset_str = \
                 self.model.get_asset_by_id(left_asset_id).name + \
-                '(' + str(left_asset_id) + ')'
+                '(' + str(left_asset_id) + '/' + str(left_asset_index) + ')'
             right_asset_str = \
                 self.model.get_asset_by_id(right_asset_id).name + \
-                '(' + str(right_asset_id) + ')'
+                '(' + str(right_asset_id) + '/' + str(right_asset_index) + ')'
             entries.append(
                 [
                     entry,

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -572,9 +572,24 @@ class MalSimulator(ParallelEnv):
             self.model.get_association_field_names(association)
         left_field = getattr(association, left_field_name)
         right_field = getattr(association, right_field_name)
-        assoc_full_name = assoc_name + '_' + \
-            left_field[0].type + '_' + \
+        lang_assoc = self.lang_graph.get_association_by_fields_and_assets(
+            left_field_name,
+            right_field_name,
+            left_field[0].type,
             right_field[0].type
+        )
+        if lang_assoc is None:
+            raise LookupError('Failed to find association for fields '
+                '"%s" "%s" and asset types "%s" "%s"!' % (
+                    left_field_name,
+                    right_field_name,
+                    left_field[0].type,
+                    right_field[0].type
+                )
+            )
+        assoc_full_name = lang_assoc.name + '_' + \
+            lang_assoc.left_field.asset.name + '_' + \
+            lang_assoc.right_field.asset.name
         return assoc_full_name
 
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -137,8 +137,17 @@ def test_malsimulator_observation_space(corelang_lang_graph, model):
     sim = MalSimulator(corelang_lang_graph, model, attack_graph)
     observation_space = sim.observation_space()
     assert set(observation_space.keys()) == {
-        'is_observable', 'observed_state', 'remaining_ttc',
-        'asset_type', 'asset_id', 'step_name', 'attack_graph_edges'
+        'is_observable',
+        'observed_state',
+        'remaining_ttc',
+        'asset_type',
+        'asset_id',
+        'step_name',
+        'attack_graph_edges',
+        'model_asset_id',
+        'model_asset_type',
+        'model_edges_ids',
+        'model_edges_type',
     }
     # All values in the observation space dict are of type Box
     # which comes from gymnasium.spaces (Box is a Space)


### PR DESCRIPTION
Four new entries have been added to the observation to provide the agent the instance model that was used to generate the attack graph.

- `model_asset_id` - provides the asset id, its unique identifier, not its name
- `model_asset_type` - provides the asset type
- `model_edges_ids` - provides pairs of associated assets
- `model_edges_type` - provides the association type in the following format: `<association_name>_<left_asset_type>_<right_asset_type>`

Based on this information the agent should be able to recreate the instance model or use the information as is.