### PR TITLE
Add true state + Better obs and rewards responsibilty

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -908,15 +908,15 @@ class MalSimulator(ParallelEnv):
 
             node_id = self._index_to_id[step_index]
             node = self.attack_graph.get_node_by_id(node_id)
-            if node.type in ('or', 'and'):
-                # Attack step activated, set to 1 (enabled)
-                attacker_obs["observed_state"][step_index] = 1
 
-                for child in node.children:
-                    # Set its children to 0 (disabled)
-                    child_index = self._id_to_index[child.id]
-                    if attacker_obs["observed_state"][child_index] == -1:
-                        attacker_obs["observed_state"][child_index] = 0
+            # Attack step activated, set to 1 (enabled)
+            attacker_obs["observed_state"][step_index] = 1
+
+            for child in node.children:
+                # Set its children to 0 (disabled)
+                child_index = self._id_to_index[child.id]
+                if attacker_obs["observed_state"][child_index] == -1:
+                    attacker_obs["observed_state"][child_index] = 0
 
         # Disable disabled attack steps in attacker obs state
         for node in disabled_steps_per_attacker.get(attacker_agent, []):

--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -927,8 +927,7 @@ class MalSimulator(ParallelEnv):
     def _observe_defender(
             self,
             defender_agent,
-            performed_actions_per_agent: dict[str, list[int]],
-            disabled_steps_per_attacker: dict
+            performed_actions_per_agent: dict[str, list[int]]
         ):
         """Update a defender agents observation
 
@@ -958,12 +957,6 @@ class MalSimulator(ParallelEnv):
                 for action in actions:
                     defender_obs['observed_state'][action] = 1
 
-            # Disable disabled attacks steps in observation
-            for _, nodes in disabled_steps_per_attacker.items():
-                for node in nodes:
-                    index = self._id_to_index[node.id]
-                    defender_obs['observed_state'][index] = 0
-
     def _observe_agents(
             self,
             performed_actions_per_agent: dict,
@@ -984,11 +977,16 @@ class MalSimulator(ParallelEnv):
             agent_type = self.agents_dict[agent]["type"]
             if  agent_type == "defender":
                 self._observe_defender(
-                    agent, performed_actions_per_agent, disabled_steps_per_attacker)
+                    agent,
+                    performed_actions_per_agent
+                )
 
             elif agent_type == "attacker":
                 self._observe_attacker(
-                    agent, performed_actions_per_agent, disabled_steps_per_attacker)
+                    agent,
+                    performed_actions_per_agent,
+                    disabled_steps_per_attacker
+                )
 
             else:
                 logger.error(


### PR DESCRIPTION
## Add true state obs

Add true_obs_state to MalSimulator containing the true observed_state of the attackgraph.

The defender observation will be equal to the true obs state if defender observation is cumulative.

Non cumulative defender observation will simply enable the latest performed steps.


## Move responsibility over obs and rewards to those methods, rename variables for clarity
    
  - Less responsibility in _disable_attack_steps
          - It now only does what it says in its name
          - It returns the disabled_steps_per_attacker that can be used where needed
  - Add the `disabled_steps_per_attacker` to  observe and reward methods and use it to observe and reward
  - Rename `performed_actions` to `performed_actions_per_agent` to clarify its a mapping from agents to actions