### PR TITLE
Fix entry point id lookup in initial actions collection

### DIFF
--- a/malsim/sims/mal_simulator.py
+++ b/malsim/sims/mal_simulator.py
@@ -659,8 +659,7 @@ class MalSimulator(ParallelEnv):
 
                 # Initial actions for attacker are its entrypoints
                 for entry_point in attacker.entry_points:
-                    initial_actions[agent].append(
-                        self._id_to_index[entry_point.id])
+                    initial_actions[agent].append(entry_point.id)
                     entry_point.extras['entrypoint'] = True
 
             elif agent_type == "defender":


### PR DESCRIPTION
When an attack graph gets constructed, nodes are added to it with IDs that are sequential and map exactly to the nodes' indices in the graph's node list. (In case we are loading from a file, the node IDs are used as described in the file; but this makes no difference to the rest of the discussion). 

In the simulator, when an attack graph gets loaded, pruning of nonviable and unnecessary nodes may happen:

https://github.com/mal-lang/mal-simulator/blob/599e47a21eaa302b5ac9c509342082c19d3c5b9b/malsim/sims/mal_simulator.py#L83-L85

(BTW, wouldn't it be more fitting if `prune_unviable_unnecessary`) was a sim setting?)

This will result in indices in `attack_graph.nodes` not mapping to the `node.id`s anymore. That's fine, we have the `MalSimulator._id_to_index` and `_index_to_id` properties to follow the nodes in the list. 

The issue here, when collecting the initial actions, is that there is no reason to go from the `node.id` to the list index. If  truncation is in place this will result in the wrong node being picked up. There is no way for the user to control this, at least if they start with a handcrafted model file, or one generated via Securicad (and potentially the KTH UI tool), together with a MAL file; node IDs do not appear in any of those.

I believe there is a broader issue in the simulator when truncation happens, i.e. there may be more places where the translation between indices and node IDs is either missing or messing. For example a few lines below my edit, for the defender.