### PR TITLE
Implements suggestions made in PR #87

### DIFF
--- a/.github/workflows/test-pytest.yml
+++ b/.github/workflows/test-pytest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          pip install ".[ml]"
           pip install pytest
       - name: Test with pytest
         run: |

--- a/malsim/__main__.py
+++ b/malsim/__main__.py
@@ -38,7 +38,7 @@ def run_simulation(sim: MalSimulator, agents: list[dict]):
                 )
                 continue
 
-            sim_agent_state = sim.get_agent_state(agent_name)
+            sim_agent_state = sim.agent_states[agent_name]
             agent_action = decision_agent.get_next_action(sim_agent_state)
             if agent_action:
                 actions[agent_name] = [agent_action]
@@ -52,7 +52,7 @@ def run_simulation(sim: MalSimulator, agents: list[dict]):
 
         for agent_dict in agents:
             agent_name = agent_dict['name']
-            agent_state = sim.get_agent_state(agent_name)
+            agent_state = sim.agent_states[agent_name]
             total_rewards[agent_name] += agent_state.reward
             if not agent_state.terminated and not agent_state.truncated:
                 all_agents_term_or_trunc = False
@@ -80,10 +80,7 @@ def main():
     )
     args = parser.parse_args()
 
-    sim, agents = \
-        create_simulator_from_scenario(
-            args.scenario_file,
-        )
+    sim, agents = create_simulator_from_scenario(args.scenario_file)
 
     if args.output_attack_graph:
         sim.attack_graph.save_to_file(args.output_attack_graph)

--- a/malsim/agents/keyboard_input.py
+++ b/malsim/agents/keyboard_input.py
@@ -19,7 +19,7 @@ class KeyboardAgent(DecisionAgent):
 
     def get_next_action(
             self,
-            agent: MalSimAgentStateView,
+            agent_state: MalSimAgentStateView,
             **kwargs
         ) -> Optional[AttackGraphNode]:
         """Compute action from action_surface"""
@@ -33,17 +33,17 @@ class KeyboardAgent(DecisionAgent):
             except ValueError:
                 return False
 
-            return 0 <= node <= len(agent.action_surface)
+            return 0 <= node <= len(agent_state.action_surface)
 
         def get_action_object(user_input: str) -> tuple:
             node = int(user_input) if user_input != "" else None
             return node
 
-        if not agent.action_surface:
+        if not agent_state.action_surface:
             print("No actions to pick for defender")
             return []
 
-        index_to_node = dict(enumerate(agent.action_surface))
+        index_to_node = dict(enumerate(agent_state.action_surface))
         user_input = "xxx"
         while not valid_action(user_input):
             print("Available actions:")

--- a/malsim/wrappers/base_classes.py
+++ b/malsim/wrappers/base_classes.py
@@ -24,7 +24,7 @@ class MalSimEnv(ABC):
         self.sim.register_defender(defender_name)
 
     def get_agent_state(self, agent_name: str) -> MalSimAgentStateView:
-        return self.sim.get_agent_state(agent_name)
+        return self.sim.agent_states[agent_name]
 
     def render(self):
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "py2neo>=2021.2.3",
-  "python-jsonschema-objects>=0.4.1",
   "mal-toolbox>=0.3,<0.4",
-  "numpy>=1.21.4",
-  "pettingzoo>=1.24.2",
-  "gymnasium==1.0",
   "PyYAML>=6.0.1"
 ]
 license = {text = "Apache Software License"}
@@ -29,6 +25,18 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering"
+]
+
+[project.optional-dependencies]
+ml = [
+  "numpy>=1.21.4",
+  "pettingzoo>=1.24.2",
+  "gymnasium==1.0",
+]
+dev = [
+  "pytest",
+  "mypy",
+  "ruff",
 ]
 
 [project.urls]

--- a/tests/agents/test_searchers.py
+++ b/tests/agents/test_searchers.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 from maltoolbox.attackgraph import AttackGraphNode, Attacker
-from maltoolbox.attackgraph.query import get_attack_surface
+from maltoolbox.attackgraph.query import calculate_attack_surface
 from maltoolbox.language import LanguageGraph
 from malsim.mal_simulator import MalSimAgentStateView
 from malsim.agents import BreadthFirstAttacker, DepthFirstAttacker
@@ -64,7 +64,7 @@ def test_breadth_first_traversal_simple(dummy_lang_graph: LanguageGraph):
 
         # Mark node as compromised
         attacker.compromise(action_node)
-        agent.action_surface = get_attack_surface(attacker)
+        agent.action_surface = calculate_attack_surface(attacker)
 
         # Store the ID for verification
         actual_order.append(action_node.id)
@@ -144,13 +144,14 @@ def test_breadth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
 
         # Mark node as compromised
         attacker.compromise(action_node)
-        agent.action_surface = get_attack_surface(attacker)
+        agent.action_surface = calculate_attack_surface(attacker)
 
         # Store the ID for verification
         actual_order.append(action_node.id)
 
-    assert actual_order == expected_order, \
-        "Traversal order does not match expected breadth-first order"
+    for level in (0, 1), (1, 4), (4, 8):
+        assert set(expected_order[level[0]:level[1]]) == set(actual_order[level[0]:level[1]]), \
+            "Traversal order does not match expected breadth-first order"
 
 
 def test_depth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
@@ -224,7 +225,7 @@ def test_depth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
 
         # Mark node as compromised
         attacker.compromise(action_node)
-        agent.action_surface = get_attack_surface(attacker)
+        agent.action_surface = calculate_attack_surface(attacker)
 
         # Store the ID for verification
         actual_order.append(action_node.id)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -52,8 +52,6 @@ def test_gym():
     )
     env_checker.check_env(env.unwrapped)
 
-    pass
-
 
 def test_random_defender_actions():
     register_gym_agent('MALDefenderEnv-v0', entry_point=DefenderEnv)
@@ -105,7 +103,7 @@ def test_episode():
 
 
 def test_mask():
-    gym.register('MALDefenderEnv-v0', entry_point=DefenderEnv)
+    register_gym_agent('MALDefenderEnv-v0', entry_point=DefenderEnv)
     env = gym.make(
         'MALDefenderEnv-v0',
         scenario_file='tests/testdata/scenarios/simple_scenario.yml',

--- a/tests/sims/test_example_scenarios.py
+++ b/tests/sims/test_example_scenarios.py
@@ -44,11 +44,11 @@ def test_bfs_vs_bfs_state_and_reward():
         # Run the simulation until agents are terminated/truncated
 
         # Select attacker node
-        attacker_agent_state = sim.get_agent_state(attacker_agent_info["name"])
+        attacker_agent_state = sim.agent_states[attacker_agent_info["name"]]
         attacker_node = attacker_agent.get_next_action(attacker_agent_state)
 
         # Select defender node
-        defender_agent_state = sim.get_agent_state(defender_agent_info["name"])
+        defender_agent_state = sim.agent_states[defender_agent_info["name"]]
         defender_node = defender_agent.get_next_action(defender_agent_state)
 
         # Step
@@ -56,13 +56,15 @@ def test_bfs_vs_bfs_state_and_reward():
             defender_agent_name: [defender_node] if defender_node else [],
             attacker_agent_name: [attacker_node] if attacker_node else []
         }
-        performed_actions, _ = sim.step(actions)
+        states = sim.step(actions)
 
         # If actions were performed, add them to respective list
-        if attacker_node and attacker_node in performed_actions:
+        if attacker_node and attacker_node in \
+                states['attacker1'].step_compromised_nodes:
             attacker_actions.append(attacker_node.full_name)
 
-        if defender_node and defender_node in performed_actions:
+        if defender_node and defender_node in \
+                states['defender1'].step_enabled_defenses:
             defender_actions.append(defender_node.full_name)
 
         total_reward_defender += defender_agent_state.reward

--- a/tests/sims/test_vectorized_obs_mal_simulator.py
+++ b/tests/sims/test_vectorized_obs_mal_simulator.py
@@ -220,13 +220,14 @@ def test_step(corelang_lang_graph, model):
     # Can not attack the notPresent step
     defense_step = attack_graph\
         .get_node_by_full_name('OS App:notPresent')
-    actions = env.sim._attacker_step(agent_info, [defense_step])
+    actions, new_surface = env.sim._attacker_step(agent_info, {defense_step})
     assert not actions
+    assert not new_surface
 
-    # Can attack the attemptRead step
     attack_step = attack_graph.get_node_by_full_name('OS App:attemptRead')
-    actions = env.sim._attacker_step(agent_info, [attack_step])
-    assert actions == [attack_step]
+    actions, new_surface = env.sim._attacker_step(agent_info, {attack_step})
+    assert actions == {attack_step}
+    assert new_surface == attack_step.children
 
 
 def test_malsimulator_defender_step(corelang_lang_graph, model):
@@ -239,13 +240,13 @@ def test_malsimulator_defender_step(corelang_lang_graph, model):
 
     defense_step = env.sim.attack_graph.get_node_by_full_name(
         'OS App:notPresent')
-    enabled, _ = env.sim._defender_step(env.sim._agents_dict[agent_name], [defense_step])
-    assert enabled == [defense_step]
+    enabled, _ = env.sim._defender_step(env.sim.agents[agent_name], {defense_step})
+    assert enabled == {defense_step}
 
     # Can not defend attack_step
     attack_step = env.sim.attack_graph.get_node_by_full_name(
         'OS App:attemptUseVulnerability')
-    actions, _ = env.sim._defender_step(env.sim._agents_dict[agent_name], [attack_step])
+    actions, _ = env.sim._defender_step(env.sim.agents[agent_name], {attack_step})
     assert not actions
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,8 @@
 import os
 from unittest.mock import patch
 
+from malsim.__main__ import run_simulation
 from malsim.scenario import create_simulator_from_scenario
-from malsim.cli import run_simulation
 from malsim.mal_simulator import MalSimulator
 
 

--- a/tests/testdata/scenarios/bfs_vs_bfs_network_app_data_scenario.yml
+++ b/tests/testdata/scenarios/bfs_vs_bfs_network_app_data_scenario.yml
@@ -10,9 +10,13 @@ agents:
   'attacker1':
     agent_class: BreadthFirstAttacker
     type: attacker
+    config:
+      seed: 1
     entry_points:
       - 'Internet:accessUninspected'
 
   'defender1':
     agent_class: BreadthFirstAttacker
     type: defender
+    config:
+      seed: 1

--- a/tests/testdata/scenarios/no_defender_agent_scenario.yml
+++ b/tests/testdata/scenarios/no_defender_agent_scenario.yml
@@ -18,6 +18,8 @@ rewards:
 agents:
   'attacker1':
     type: attacker
-    agent_class: BreadthFirstAttacker 
+    agent_class: BreadthFirstAttacker
+    config:
+      seed: 1
     entry_points:
       - 'Credentials:6:attemptCredentialsReuse'

--- a/tests/testdata/scenarios/simple_scenario.yml
+++ b/tests/testdata/scenarios/simple_scenario.yml
@@ -19,6 +19,8 @@ agents:
   'Attacker1':
     type: attacker
     agent_class: BreadthFirstAttacker
+    config:
+      seed: 1
     entry_points:
     - 'Credentials:6:attemptCredentialsReuse'
 


### PR DESCRIPTION
I implemented here most of my suggestions in #87. See the commit messages for what they do. They tests fail because the mal-toolbox version used here is missing https://github.com/mal-lang/mal-toolbox/pull/121. When this gets merged, the tests will also pass. The suggestions I did not implement have to do with renaming folders/files as that would make following the changes harder. There are also a couple TODOs added imin the code about things not clear to me. Depending on what the answer is to those TODOs the code may be possible to simplify in some parts.

One of the things this PR does is change what `def step` returns. It now returns three things:

1. actioned_nodes, i.e. the nodes that each attacker/defender agent has compromised/enabled. This is a dict and each agent receives only what is relevant to them
1. new_attack_surface, this is also a dict and contains the new steps that became available in the latest timestep to each agent.  This is set only for attackers, since defenders start with an defense surface that contains all defenses and defenses get removed as they are enabled, thus no new defense surface ever becomes available. 
1. disabled nodes: the nodes that became disabled in the last timestep due to defender actions. This is a simple set that is common to all agents.

1 was changed from what is currently in #87 to be a dict, 2 is a new addition and 3 is left as is.

The advantage of having 2 available is that this info can be passed to the agents and they don't have to calculate it themselves.

While the above works, I think it would be better if we extended the `MalSimAgentState` class with three new keys to hold the three bits of information above:

```
@dataclass
class MalSimAgentState:
    """Stores the state of an agent in the simulator"""

    # Identifier of the agent, used in MalSimulator for lookup
    name: str
    type: AgentType

    # Contains current agent reward in the simulation
    # Attackers get positive rewards, defenders negative
    reward: int = 0

    # Contains possible actions for the agent in the next step
    action_surface: set[AttackGraphNode] = field(default_factory=set)
    new_action_surface: ....
    actioned_nodes: ....
    disabled_nodes: ....

    # Fields that tell if agent is 'dead' / disabled
    truncated: bool = False
    terminated: bool = False

    # Fields that are not used by 'base' MalSimulator
    # but can be useful in wrappers/envs
    observation: dict = field(default_factory=dict)
    info: dict = field(default_factory=dict)
```

I think it is natural to do this as these change on every time step. And if we accept action_surface to be a good fit for this class, then these three surely are as well.

If the above happens (trivial), then the return value of `step()` could change to sth simpler and more intuititve, i.e. a dict like:

```
{
    "attacker1": MalSimAgentState(....for-attacker1...),
    "defender1": MalSimAgentState(....for-defender1....),
```