### PR TITLE
Have keyboard agent (attacker) only show not yet compromised nodes when asking user to pick action

### DIFF
--- a/malsim/agents/keyboard_input.py
+++ b/malsim/agents/keyboard_input.py
@@ -33,23 +33,26 @@ class KeyboardAgent(DecisionAgent):
             except ValueError:
                 return False
 
-            return 0 <= node <= len(agent_state.action_surface)
+            return 0 <= node < len(agent_state.action_surface)
 
-        def get_action_object(user_input: str) -> tuple:
-            node = int(user_input) if user_input != "" else None
-            return node
+        def get_action_object(user_input: str) -> Optional[int]:
+            node_index = int(user_input) if user_input != "" else None
+            return node_index
 
         if not agent_state.action_surface:
             print("No actions to pick for defender")
-            return []
+            return None
 
-        index_to_node = dict(enumerate(agent_state.action_surface))
+        index_to_node = [
+            n for n in agent_state.action_surface
+            if not n.is_compromised()
+        ]
         user_input = "xxx"
         while not valid_action(user_input):
             print("Available actions:")
             print(
                 "\n".join(
-                    [f"{i}. {n.full_name}" for i, n in index_to_node.items()]
+                    [f"{i}. {n.full_name}" for i, n in enumerate(index_to_node)]
                 )
             )
             print("Enter action or leave empty to wait:")


### PR DESCRIPTION
We have a KeyboardAgent that lets the user pick actions.

If an attacker is run using the KeyboardAgent, the user will be allowed to pick the same attack step as many times as they want to since it does not disappear from an attacker action surface, unlike defenders.  With the current implementation the action surface only grows and therefore the list of possible attacker choices in the KeyboardAgent also grows until it contains all attack steps.

This is not useful for users that want to use the KeyboardAgent.
