### PR TITLE
Less verbose logging when used as lib

### DIFF
--- a/malsim/__main__.py
+++ b/malsim/__main__.py
@@ -12,6 +12,18 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger().setLevel(logging.INFO)
 
+
+def debug_to_info(record):
+    record.levelname = 'INFO'
+    record.levelno = logging.DEBUG
+    return True
+
+
+module_logger = logging.getLogger('malsim.mal_simulator')
+module_logger.setLevel(logging.DEBUG)
+module_logger.filters.append(debug_to_info)
+
+
 def run_simulation(sim: MalSimulator, agents: list[dict]):
     """Run a simulation with agents"""
 

--- a/malsim/mal_simulator.py
+++ b/malsim/mal_simulator.py
@@ -330,7 +330,7 @@ class MalSimulator():
                 "comes from the agents action surface."
             )
 
-            logger.info(
+            logger.debug(
                 'Attacker agent "%s" stepping through "%s"(%d).',
                 agent.name, node.full_name, node.id
             )
@@ -342,7 +342,7 @@ class MalSimulator():
                 agent.reward += node.extras.get('reward', 0)
                 compromised_nodes.add(node)
 
-                logger.info(
+                logger.debug(
                     'Attacker agent "%s" compromised "%s"(%d).',
                     agent.name, node.full_name, node.id
                 )
@@ -394,7 +394,7 @@ class MalSimulator():
                 "of this simulators attack_graph. Make sure the node "
                 "comes from the agents action surface."
             )
-            logger.info(
+            logger.debug(
                 'Defender agent "%s" stepping through "%s"(%d).',
                 agent.name, node.full_name, node.id
             )
@@ -415,7 +415,7 @@ class MalSimulator():
                     apriori.propagate_viability_from_unviable_node(node)
                 agent.reward -= node.extras.get("reward", 0)
                 enabled_defenses.add(node)
-                logger.info(
+                logger.debug(
                     'Defender agent "%s" enabled "%s"(%d).',
                     agent.name, node.full_name, node.id
                 )
@@ -451,10 +451,9 @@ class MalSimulator():
         Returns:
         - A dictionary containing the agent state views keyed by agent names
         """
-        logger.info(
+        logger.debug(
             "Stepping through iteration %d/%d", self.cur_iter, self.max_iter
         )
-        logger.debug("Performing actions: %s", actions)
 
         # Populate these from the results for all agents' actions.
         all_compromised = set()


### PR DESCRIPTION
When running the simulator as an app (`malsim` command), debugging is kept mostly the same as before. When used as an imported module, logging is less verbose.

See also #101 .