### PR TITLE
Searcher agents allow same node to be selected more than once + forma…

### DIFF
--- a/malsim/agents/searchers.py
+++ b/malsim/agents/searchers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import logging
 import random
-import re
 
 from collections import deque
 from typing import Optional, TYPE_CHECKING, Any
@@ -18,92 +17,100 @@ logger = logging.getLogger(__name__)
 class BreadthFirstAttacker(DecisionAgent):
     """A Breadth-First agent, with possible randomization at each level."""
 
-    _extend_method = 'extendleft'
-    # Controls where newly discovered steps will be appended to the list of
-    # available actions. Currently used to differentiate between BFS and DFS
-    # agents.
-
-    name = ' '.join(re.findall(r'[A-Z][^A-Z]*', __qualname__))
     # A human-friendly name for the agent.
+    name = 'Breadth First Attacker'
 
-    default_settings: dict[str, Any] = {
-        'randomize': False,
+    # Controls where newly discovered steps will be appended to the deque of
+    # available actions. Differentiates between BFS and DFS agents.
+    _extend_method = 'extendleft'
+
+    _default_settings: dict[str, Any] = {
         # Whether to randomize next target selection, still respecting the
-        # policy of the agent (e.g. BFS or DFS).
+        # policy of the agent (BFS or DFS).
+        'randomize': False,
+        # The random seed to initialize the randomness engine with.
+        # If set, the simulation will be deterministic.
         'seed': None,
-        # The random seed to initialize the randomness engine with. If set, the
-        # simulation will be deterministic.
     }
 
     def __init__(self, agent_config: dict) -> None:
-        """Initialize a BFS agent.
+        """Initialize a BFS/DFS agent.
 
         Args:
             agent_config: Dict with settings to override defaults
         """
-        self.targets: deque[AttackGraphNode] = deque()
-        self.current_target: Optional[AttackGraphNode] = None
+        self._targets: deque[AttackGraphNode] = deque()
+        self._current_target: Optional[AttackGraphNode] = None
+        self._settings = self._default_settings | agent_config
 
-        self.settings = self.default_settings | agent_config
-
-        self.rng = random.Random(self.settings.get('seed'))
-        self.started = False
+        self.rng = random.Random(self._settings.get('seed'))
+        self._started = False
 
     def get_next_action(
         self, agent_state: MalSimAgentStateView, **kwargs
     ) -> Optional[AttackGraphNode]:
-        self._update_targets(
-            agent_state.step_action_surface_additions
-            if self.started
-            else agent_state.action_surface,
-            agent_state.step_action_surface_removals,
-            **kwargs,
-        )
-        self._select_next_target(**kwargs)
+        """Receive the next action according to agent policy (bfs/dfs)"""
 
-        self.started = True
-        return self.current_target
+        self._update_targets(
+            new_nodes=(
+                agent_state.step_action_surface_additions
+                if self._started else agent_state.action_surface
+            ),
+            disabled_nodes=(
+                agent_state.step_action_surface_removals
+            )
+        )
+
+        self._select_next_target()
+        self._started = True
+        return self._current_target
 
     def _update_targets(
         self,
-        new_targets_set: set[AttackGraphNode],
-        disabled_nodes_set: set[AttackGraphNode],
-        **kwargs: Any,
+        new_nodes: set[AttackGraphNode],
+        disabled_nodes: set[AttackGraphNode],
     ):
-        if self.settings['seed']:
+        new_targets: list[AttackGraphNode] = []
+        if self._settings['seed']:
             # If a seed is set, we assume the user wants determinism in the
             # simulation. Thus, we sort to an ordered list to make sure the
             # non-deterministic ordering of the action_surface set does not
             # break simulation determinism.
-            new_targets = sorted(new_targets_set, key=lambda n: n.id)
+            new_targets = sorted(new_nodes, key=lambda n: n.id)
         else:
             # sorted above returns a list already
-            new_targets = list(new_targets_set)
+            new_targets = list(new_nodes)
 
-        if self.settings['randomize']:
+        if self._settings['randomize']:
             self.rng.shuffle(new_targets)
 
-        if self.current_target in new_targets:
-            # If self.current_target is not yet compromised, e.g. due to TTCs,
-            # keep using that as the target.
-            new_targets.remove(self.current_target)
-            new_targets.append(self.current_target)
+        if (
+            self._current_target
+            and not self._current_target.is_compromised()
+            and self._current_target not in disabled_nodes
+        ):
+            # If self.current_target was not compromised, e.g. due to TTCs,
+            # it remains in action surface and should be added as a target.
+            self._targets.append(self._current_target)
 
         # Enabled defenses may remove previously possible attack steps.
-        if disabled_nodes_set:
-            self.targets = deque(n for n in self.targets if n.is_viable)
+        for node in disabled_nodes:
+            if node in self._targets:
+                self._targets.remove(node)
 
-        getattr(self.targets, self._extend_method)(new_targets)
+        # Use the extend method to add new targets
+        getattr(self._targets, self._extend_method)(new_targets)
 
-    def _select_next_target(self, **kwargs: Any) -> None:
+    def _select_next_target(self) -> None:
         """
         Implement the actual next target selection logic.
         """
-        try:
-            self.current_target = self.targets.pop()
-        except IndexError:
-            self.current_target = None
+        if self._targets:
+            self._current_target = self._targets.pop()
+        else:
+            self._current_target = None
 
 
 class DepthFirstAttacker(BreadthFirstAttacker):
+    name = 'Depth First Attacker'
     _extend_method = 'extend'

--- a/malsim/agents/searchers.py
+++ b/malsim/agents/searchers.py
@@ -43,7 +43,7 @@ class BreadthFirstAttacker(DecisionAgent):
         self._current_target: Optional[AttackGraphNode] = None
         self._settings = self._default_settings | agent_config
 
-        self.rng = random.Random(self._settings.get('seed'))
+        self._rng = random.Random(self._settings.get('seed'))
         self._started = False
 
     def get_next_action(
@@ -82,7 +82,7 @@ class BreadthFirstAttacker(DecisionAgent):
             new_targets = list(new_nodes)
 
         if self._settings['randomize']:
-            self.rng.shuffle(new_targets)
+            self._rng.shuffle(new_targets)
 
         if (
             self._current_target
@@ -94,9 +94,10 @@ class BreadthFirstAttacker(DecisionAgent):
             self._targets.append(self._current_target)
 
         # Enabled defenses may remove previously possible attack steps.
-        for node in disabled_nodes:
-            if node in self._targets:
-                self._targets.remove(node)
+        if disabled_nodes:
+            self._targets = deque(
+                n for n in self._targets if n not in disabled_nodes
+            )
 
         # Use the extend method to add new targets
         getattr(self._targets, self._extend_method)(new_targets)


### PR DESCRIPTION
…tting

- Allow agents to pick a node that was previously picked (if it was not compromised and not removed)
- Make instance variables private (except for .name)
- Make sure .name works for both BFS and DFS
- Comments/Docstrings/variable naming