### PR TITLE
Make AgentState a read only dataclass rebuilt every time

### DIFF
--- a/malsim/__main__.py
+++ b/malsim/__main__.py
@@ -15,7 +15,7 @@ logging.getLogger().setLevel(logging.INFO)
 def run_simulation(sim: MalSimulator, agents: list[dict]):
     """Run a simulation with agents"""
 
-    sim.reset()
+    agent_states = sim.reset()
     total_rewards = {agent_dict['name']: 0 for agent_dict in agents}
     all_agents_term_or_trunc = False
 
@@ -38,7 +38,7 @@ def run_simulation(sim: MalSimulator, agents: list[dict]):
                 )
                 continue
 
-            sim_agent_state = sim.agent_states[agent_name]
+            sim_agent_state = agent_states[agent_name]
             agent_action = decision_agent.get_next_action(sim_agent_state)
             if agent_action:
                 actions[agent_name] = [agent_action]
@@ -48,11 +48,11 @@ def run_simulation(sim: MalSimulator, agents: list[dict]):
                 )
 
         # Perform next step of simulation
-        sim.step(actions)
+        agent_states = sim.step(actions)
 
         for agent_dict in agents:
             agent_name = agent_dict['name']
-            agent_state = sim.agent_states[agent_name]
+            agent_state = agent_states[agent_name]
             total_rewards[agent_name] += agent_state.reward
             if not agent_state.terminated and not agent_state.truncated:
                 all_agents_term_or_trunc = False

--- a/malsim/agents/decision_agent.py
+++ b/malsim/agents/decision_agent.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional
 from abc import ABC, abstractmethod
 
 if TYPE_CHECKING:
-    from ..mal_simulator import MalSimAgentStateView
+    from ..mal_simulator import AgentState
     from maltoolbox.attackgraph import AttackGraphNode
 
 class DecisionAgent(ABC):
@@ -13,7 +13,7 @@ class DecisionAgent(ABC):
     @abstractmethod
     def get_next_action(
         self,
-        agent_state: MalSimAgentStateView,
+        agent_state: AgentState,
         **kwargs
     ) -> Optional[AttackGraphNode]:
         """

--- a/malsim/agents/keyboard_input.py
+++ b/malsim/agents/keyboard_input.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from .decision_agent import DecisionAgent
-from ..mal_simulator import MalSimAgentStateView
+from ..mal_simulator import AgentState
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
@@ -19,7 +19,7 @@ class KeyboardAgent(DecisionAgent):
 
     def get_next_action(
             self,
-            agent_state: MalSimAgentStateView,
+            agent_state: AgentState,
             **kwargs
         ) -> Optional[AttackGraphNode]:
         """Compute action from action_surface"""

--- a/malsim/agents/passive_agent.py
+++ b/malsim/agents/passive_agent.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 from .decision_agent import DecisionAgent
-from ..mal_simulator import MalSimAgentStateView
+from ..mal_simulator import AgentState
 
 if TYPE_CHECKING:
-    from ..mal_simulator import MalSimAgentStateView
+    from ..mal_simulator import AgentState
     from maltoolbox.attackgraph import AttackGraphNode
 
 class PassiveAgent(DecisionAgent):
@@ -16,7 +16,7 @@ class PassiveAgent(DecisionAgent):
 
     def get_next_action(
         self,
-        agent_state: MalSimAgentStateView,
+        agent_state: AgentState,
         **kwargs
     ) -> Optional[AttackGraphNode]:
         # A passive agent never does anything

--- a/malsim/agents/searchers.py
+++ b/malsim/agents/searchers.py
@@ -7,7 +7,7 @@ from collections import deque
 from typing import Optional, TYPE_CHECKING, Any
 
 from .decision_agent import DecisionAgent
-from ..mal_simulator import MalSimAgentStateView
+from ..mal_simulator import AgentState
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
@@ -50,7 +50,7 @@ class BreadthFirstAttacker(DecisionAgent):
         self.started = False
 
     def get_next_action(
-        self, agent_state: MalSimAgentStateView, **kwargs
+        self, agent_state: AgentState, **kwargs
     ) -> Optional[AttackGraphNode]:
         self._update_targets(
             agent_state.step_action_surface_additions

--- a/malsim/envs/base_classes.py
+++ b/malsim/envs/base_classes.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from ..mal_simulator import MalSimulator, MalSimAgentStateView
+from ..mal_simulator import AgentState, MalSimulator
 
 class MalSimEnv(ABC):
 
@@ -11,19 +11,19 @@ class MalSimEnv(ABC):
         ...
 
     def reset(self, seed=None, options=None):
-        self.sim.reset(seed=seed, options=options)
+        return self.sim.reset(seed=seed, options=options)
 
     def register_attacker(
             self, attacker_name: str, attacker_id: int
         ):
-        self.sim.register_attacker(attacker_name, attacker_id)
+        return self.sim.register_attacker(attacker_name, attacker_id)
 
     def register_defender(
             self, defender_name: str
         ):
-        self.sim.register_defender(defender_name)
+        return self.sim.register_defender(defender_name)
 
-    def get_agent_state(self, agent_name: str) -> MalSimAgentStateView:
+    def get_agent_state(self, agent_name: str) -> AgentState:
         return self.sim.agent_states[agent_name]
 
     def render(self):

--- a/malsim/envs/malsim_vectorized_obs_env.py
+++ b/malsim/envs/malsim_vectorized_obs_env.py
@@ -19,9 +19,9 @@ from maltoolbox.attackgraph import AttackGraphNode
 from ..mal_simulator import (
     MalSimulator,
     AgentType,
-    MalSimAgentStateView,
-    MalSimAttackerState,
-    MalSimDefenderState
+    AgentState,
+    AttackerState,
+    DefenderState
 )
 
 from .base_classes import MalSimEnv
@@ -390,14 +390,14 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
         self.reset()
 
     @property
-    def agents(self):
+    def agents(self) -> list[str]:
         """Required by ParallelEnv"""
         return list(self.sim._alive_agents)
 
     @property
-    def possible_agents(self):
+    def possible_agents(self) -> list[str]:
         """Required by ParallelEnv"""
-        return list(self.sim._agents)
+        return list(self.sim.agent_states.keys())
 
     def _create_blank_observation(self, default_obs_state=-1):
         """Create the initial observation"""
@@ -512,7 +512,7 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
 
         return np_obs
 
-    def create_action_mask(self, agent: MalSimAgentStateView):
+    def create_action_mask(self, agent: AgentState):
         """
         Create an action mask for an agent based on its action_surface.
 
@@ -551,8 +551,8 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
             )
         }
 
-    def _update_agent_infos(self):
-        for agent in self.sim.agent_states.values():
+    def _update_agent_infos(self, agent_states):
+        for agent in agent_states.values():
             self._agent_infos[agent.name] = self.create_action_mask(agent)
 
     def _get_association_full_name(self, association) -> str:
@@ -756,16 +756,14 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
         return nodes
 
     def register_attacker(self, attacker_name: str, attacker_id: int):
-        super().register_attacker(attacker_name, attacker_id)
-        agent = self.sim.agent_states[attacker_name]
-        self._init_agent(agent)
+        agent_state = super().register_attacker(attacker_name, attacker_id)
+        self._init_agent(agent_state)
 
     def register_defender(self, defender_name: str):
-        super().register_defender(defender_name)
-        agent = self.sim.agent_states[defender_name]
-        self._init_agent(agent)
+        agent_state = super().register_defender(defender_name)
+        self._init_agent(agent_state)
 
-    def _init_agent(self, agent: MalSimAgentStateView):
+    def _init_agent(self, agent: AgentState):
         # Fill dicts with env specific agent obs/infos
         self._agent_observations[agent.name] = \
             self._create_blank_observation()
@@ -777,7 +775,7 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
             self,
             compromised_nodes,
             disabled_nodes,
-            attacker_agent: MalSimAttackerState
+            attacker_agent: AttackerState
         ):
         """Update the observation of the serialized obs attacker"""
 
@@ -822,7 +820,7 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
             self,
             compromised_nodes: list[AttackGraphNode],
             disabled_nodes: list[AttackGraphNode],
-            defender_agent: MalSimDefenderState
+            defender_agent: DefenderState
         ):
         """Update the observation of the defender"""
 
@@ -848,11 +846,11 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
         """Reset simulator and return current
         observation and infos for each agent"""
 
-        MalSimEnv.reset(self, seed, options)
+        agent_states = MalSimEnv.reset(self, seed, options)
 
         self.attack_graph = self.sim.attack_graph # new ref
 
-        for agent in self.sim.agent_states.values():
+        for agent in agent_states.values():
             # Reset observation and action mask for agents
             self._agent_observations[agent.name] = \
                 self._create_blank_observation()
@@ -873,13 +871,13 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
             node.extras['entrypoint'] = True
 
         self._update_observations(
-            attacker_entry_points + pre_enabled_defenses, []
+            agent_states, attacker_entry_points + pre_enabled_defenses, []
         )
 
         # TODO: should we return copies instead so they are not modified externally?
         return self._agent_observations, self._agent_infos
 
-    def _update_observations(self, compromised_nodes, disabled_nodes):
+    def _update_observations(self, agent_states, compromised_nodes, disabled_nodes):
         """Update observations of all agents"""
 
         if not self.sim.sim_settings.uncompromise_untraversable_steps:
@@ -889,7 +887,7 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
         logger.debug("Enable:\n\t%s", [n.full_name for n in compromised_nodes])
         logger.debug("Disable:\n\t%s", [n.full_name for n in disabled_nodes])
 
-        for agent in self.sim.agent_states.values():
+        for agent in agent_states.values():
             if agent.type == AgentType.ATTACKER:
                 self._update_attacker_obs(
                     compromised_nodes, disabled_nodes, agent
@@ -901,7 +899,6 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
 
     def step(self, actions: dict[str, tuple[int, int]]):
         """Perform step with mal simulator and observe in parallel env"""
-
         malsim_actions = {}
         for agent_name, agent_action in actions.items():
             malsim_actions[agent_name] = []
@@ -911,17 +908,16 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
                     self.index_to_node(agent_action[1])
                 )
 
-        states = self.sim.step(malsim_actions)
+        agent_states = self.sim.step(malsim_actions)
 
         all_actioned = [
-            n
-            for state in states.values()
-            for n in state.step_performed_nodes
+            n for agent_state in agent_states.values()
+            for n in agent_state.step_performed_nodes
         ]
-        disabled_nodes = next(iter(states.values())).step_unviable_nodes
+        disabled_nodes = next(iter(agent_states.values())).step_unviable_nodes
 
-        self._update_agent_infos() # Update action masks
-        self._update_observations(all_actioned, disabled_nodes)
+        self._update_agent_infos(agent_states) # Update action masks
+        self._update_observations(agent_states, all_actioned, disabled_nodes)
 
         observations = self._agent_observations
         rewards = {}
@@ -929,7 +925,7 @@ class MalSimVectorizedObsEnv(ParallelEnv, MalSimEnv):
         truncations = {}
         infos = self._agent_infos
 
-        for agent in self.sim.agent_states.values():
+        for agent in agent_states.values():
             rewards[agent.name] = agent.reward
             terminations[agent.name] = agent.terminated
             truncations[agent.name] = agent.truncated

--- a/malsim/mal_simulator.py
+++ b/malsim/mal_simulator.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import logging
 from enum import Enum
-from types import MappingProxyType
-from typing import Any, Optional
+from typing import Optional
 
 from maltoolbox import neo4j_configs
 from maltoolbox.ingestors import neo4j
@@ -21,133 +20,44 @@ class AgentType(Enum):
     ATTACKER = 'attacker'
     DEFENDER = 'defender'
 
-
-@dataclass
-class MalSimAgentState:
-    """Stores the state of an agent in the simulator"""
-
+@dataclass(frozen=True)
+class AgentState:
+    """Read only state of an agent in the simulator"""
     # Identifier of the agent, used in MalSimulator for lookup
     name: str
-    type: AgentType
-
     # Contains current agent reward in the simulation
     # Attackers get positive rewards, defenders negative
-    reward: int = 0
-
-    # Contains the steps performed successfully in the last step
-    step_performed_nodes: set[AttackGraphNode] = field(default_factory=set)
-
+    reward: int
     # Contains possible actions for the agent in the next step
-    action_surface: set[AttackGraphNode] = field(default_factory=set)
-
+    action_surface: set[AttackGraphNode]
+    # Contains the steps performed successfully in the last step
+    step_performed_nodes: set[AttackGraphNode]
     # Contains possible actions that became available in the last step
-    step_action_surface_additions: set[AttackGraphNode] = (
-        field(default_factory = set))
-
-    # Contains previously possible actions that became unavailable in the last
-    # step
-    step_action_surface_removals: set[AttackGraphNode] = (
-        field(default_factory = set))
-
+    step_action_surface_additions: set[AttackGraphNode]
+    # Contains actions that became unavailable for the agent in the last step
+    step_action_surface_removals: set[AttackGraphNode]
     # Contains nodes that defender actions made unviable in the last step
-    step_unviable_nodes: set[AttackGraphNode] = field(default_factory=set)
-
+    step_unviable_nodes: set[AttackGraphNode]
     # Fields that tell if the agent is done or stopped
-    truncated: bool = False
-    terminated: bool = False
+    truncated: bool
+    terminated: bool
 
-
-class MalSimAttackerState(MalSimAgentState):
+@dataclass(frozen=True)
+class AttackerState(AgentState):
     """Stores the state of an attacker in the simulator"""
+    attacker_id: int
+    type: AgentType = AgentType.ATTACKER
 
-    def __init__(self, name: str, attacker_id: int):
-        super().__init__(name, AgentType.ATTACKER)
-        self.attacker_id = attacker_id
-
-
-class MalSimDefenderState(MalSimAgentState):
+@dataclass(frozen=True)
+class DefenderState(AgentState):
     """Stores the state of a defender in the simulator"""
-
-    # Contains the steps performed successfully by all of the attacker agents
-    # in the last step
-    step_all_compromised_nodes: set[AttackGraphNode] = set()
-
-    def __init__(self, name: str):
-        super().__init__(name, AgentType.DEFENDER)
-
-
-class MalSimAgentStateView(MalSimAttackerState, MalSimDefenderState):
-    """Read-only interface to MalSimAgentState.
-
-    Subclassing from State classes only to satisfy static analysis and support
-    autocompletion that would otherwise be unavailable due to the dynamic
-    __getattr(ibute)__ method.
-    """
-
-    _frozen = False
-
-    def __init__(self, agent):
-        self._agent = agent
-        self._frozen = True
-
-    def __setattr__(self, key, value) -> None:
-        if self._frozen:
-            raise AttributeError("Cannot modify agent state view")
-        super().__setattr__(key, value)
-
-    def __delattr__(self, key) -> None:
-        if self._frozen:
-            raise AttributeError("Cannot modify agent state view")
-        super().__delattr__(key)
-
-    def __getattribute__(self, attr) -> Any:
-        """Return read-only version of proxied agent's properties.
-
-        If the attribute exists in the View only return it from there. Using
-        __getattribute__ instead of __getattr__ as the latter is called only for
-        missing properties; since this class is a subclass of State, it will
-        have all state properties and those would be returned from self, not
-        self._agent. Using __getattribute__ allows use to filter which
-        properties to return from self and which from self._agent.
-        """
-        if attr in ("_agent", "_frozen") or \
-                attr.startswith("__") and attr.endswith("__"):
-            return super().__getattribute__(attr)
-
-        agent = super().__getattribute__('_agent')
-        value = getattr(agent, attr)
-
-        if attr == '_agent':
-            return agent
-
-        value = getattr(agent, attr)
-
-        if isinstance(value, dict):
-            return MappingProxyType(value)
-        if isinstance(value, list):
-            return tuple(value)
-        if isinstance(value, set):
-            return frozenset(value)
-
-        return value
-
-    def __dir__(self):
-        """Dynamically resolve attribute names for REPL autocompletion."""
-        dunder_attrs = [
-            attr
-            for attr in dir(self.__class__)
-            if attr.startswith("__") and attr.endswith("__")
-        ]
-
-        props = list(vars(self._agent).keys()) + ["_agent", "_frozen"]
-
-        return dunder_attrs + props
-
+    # Contains nodes compromised by any attacker in the last step
+    step_all_compromised_nodes: set[AttackGraphNode]
+    type: AgentType = AgentType.DEFENDER
 
 @dataclass
 class MalSimulatorSettings():
     """Contains settings used in MalSimulator"""
-
     # uncompromise_untraversable_steps
     # - Uncompromise (evict attacker) from nodes/steps that are no longer
     #   traversable (often because a defense kicked in) if set to True
@@ -155,11 +65,10 @@ class MalSimulatorSettings():
     # - Leave the node/step compromised even after it becomes untraversable
     uncompromise_untraversable_steps: bool = False
 
-
 class MalSimulator():
     """A MAL Simulator that works on the AttackGraph
 
-    Allows user to register agents (defender and attacker)
+    Allows user to register agents (defender / attacker)
     and lets the agents perform actions step by step and updates
     the state of the attack graph based on the steps chosen.
     """
@@ -190,173 +99,264 @@ class MalSimulator():
 
         # Initialize all values
         self.attack_graph = attack_graph
-
         self.sim_settings = sim_settings
         self.max_iter = max_iter  # Max iterations before stopping simulation
-        self.cur_iter = 0        # Keep track on current iteration
+        self.cur_iter = 0         # Keep track on current iteration
 
         # All internal agent states (dead or alive)
-        self._agent_states: dict[str, MalSimAgentState] = {}
+        self.agent_states: dict[str, AgentState] = {}
 
-        # Keep track on all 'living' agents sorted by order to step in
+        # Keep track on all 'living' agents
         self._alive_agents: set[str] = set()
 
-    def reset(
-        self,
-        seed: Optional[int] = None,
-        options: Optional[dict] = None
-    ) -> dict[str, MalSimAgentStateView]:
-        """Reset attack graph, iteration and reinitialize agents"""
-
-        logger.info("Resetting MAL Simulator.")
-        # Reset attack graph
-        self.attack_graph = copy.deepcopy(self.attack_graph_backup)
-        # Reset current iteration
-        self.cur_iter = 0
-        # Reset agents
-        self._reset_agents()
-
-        return self.agent_states
-
-    def _init_agent_rewards(self):
-        """Give rewards for pre-enabled attack/defense steps"""
-
-        for agent in self._get_attacker_agents():
-            attacker = self.attack_graph.attackers[agent.attacker_id]
-            agent.reward = sum(
-                n.extras.get("reward", 0) for n in attacker.reached_attack_steps
-            )
-
-        lost_reward = sum(
-            node.extras.get("reward", 0)
-            for node in self.attack_graph.nodes.values()
-            if node.is_compromised() or node.is_enabled_defense()
+    def _create_defender_state(self, name) -> DefenderState:
+        """Build a defender state based on attack graph"""
+        defense_surface = query.get_defense_surface(self.attack_graph)
+        reward = sum(
+            n.extras.get('reward', 0)
+            for n in self.attack_graph.nodes.values()
+            if n.is_compromised() or n.is_enabled_defense()
+        )
+        return DefenderState(
+            name=name,
+            reward=reward,
+            action_surface=defense_surface,
+            step_performed_nodes=set(),
+            step_action_surface_additions=set(),
+            step_action_surface_removals=set(),
+            step_unviable_nodes=set(),
+            step_all_compromised_nodes=set(),
+            truncated=False,
+            terminated=False,
         )
 
-        for agent in self._get_defender_agents():
-            agent.reward = lost_reward
+    def _create_attacker_state(self, name, attacker_id) -> AttackerState:
+        """Build an attacker state based on attack graph"""
+        attacker = self.attack_graph.attackers.get(attacker_id)
+        if not attacker:
+            raise LookupError(
+                f"Can not find attacker with id {attacker_id} in attack graph"
+            )
 
-    def _init_agent_action_surfaces(self):
-        """Set agent action surfaces according to current state"""
-        for agent in self._agent_states.values():
+        attack_surface = (
+            query.calculate_attack_surface(attacker, skip_compromised = True)
+        )
+        reward = sum(
+            n.extras.get('reward', 0)
+            for n in self.attack_graph.nodes.values()
+            if n.is_compromised_by(attacker)
+        )
+        return AttackerState(
+            name=name,
+            attacker_id=attacker_id,
+            reward=reward,
+            action_surface=attack_surface,
+            step_performed_nodes=set(),
+            step_action_surface_additions=set(),
+            step_action_surface_removals=set(),
+            step_unviable_nodes=set(),
+            truncated=False,
+            terminated=False,
+        )
 
-            if isinstance(agent, MalSimAttackerState):
-                attacker = self.attack_graph.attackers[agent.attacker_id]
-                agent.action_surface = query.calculate_attack_surface(
-                    attacker, skip_compromised = True
+    def _create_updated_attacker_state(
+            self,
+            attacker_state: AttackerState,
+            step_compromised_nodes: set[AttackGraphNode],
+            step_nodes_made_unviable: set[AttackGraphNode],
+            step_uncompromised_nodes: set[AttackGraphNode]
+        ) -> AttackerState:
+        """
+        Build attacker state from previous `attacker_state` with given
+        args. This is faster than running _create_attacker_state every time,
+        since it only adds the 'diff' to the state.
+        It will also set the additional step_* fields for the agent state.
+
+        Args:
+            - attacker_state: the old state of the attacker to update
+            - step_compromised_nodes: 
+                the steps this attacker compromised since last update
+            - step_nodes_made_unviable:
+                the steps that a defender has made unviable since last update
+            - step_uncompromised_nodes:
+                steps that were uncompromised
+                (see sim_settings.uncompromise_untraversable_steps)
+        Returns:
+            - an AttackerState based on `attacker_state` updated with the
+              given args
+        """
+        attacker = self.attack_graph.attackers[attacker_state.attacker_id]
+
+        # step action surface additions are attack surface nodes
+        # that were not already in the action surface
+        step_action_surface_additions = query.calculate_attack_surface(
+            attacker, from_nodes=step_compromised_nodes, skip_compromised=True
+        ) - attacker_state.action_surface
+
+        # step action surface removals are compromised nodes
+        # plus the unvable nodes that were previously in action surface
+        step_action_surface_removals = (
+            step_compromised_nodes
+            | (step_nodes_made_unviable & attacker_state.action_surface)
+        )
+
+        # attacker step reward is the sum of compromised node rewards
+        # minus the sum of uncompromised node rewards
+        step_reward = (
+            sum(n.extras.get('reward', 0) for n in step_compromised_nodes)
+            - sum(n.extras.get('reward', 0) for n in step_uncompromised_nodes)
+        )
+
+        # new agent action surface is old action_surface plus step action
+        # surface additions, minus step action surface removals
+        new_action_surface = (
+            (attacker_state.action_surface | step_action_surface_additions)
+            - step_action_surface_removals
+        )
+
+        return AttackerState(
+            name=attacker_state.name,
+            attacker_id=attacker_state.attacker_id,
+            reward=attacker_state.reward + step_reward,
+            action_surface=new_action_surface,
+            step_performed_nodes=step_compromised_nodes,
+            step_action_surface_additions=step_action_surface_additions,
+            step_action_surface_removals=step_action_surface_removals,
+            step_unviable_nodes=step_nodes_made_unviable,
+            truncated=self.cur_iter > self.max_iter,
+            # terminate attacker if nothing left to do
+            terminated=not new_action_surface
+        )
+
+    def _create_updated_defender_state(
+            self,
+            defender_state: DefenderState,
+            step_compromised_nodes: set[AttackGraphNode],
+            step_enabled_defenses: set[AttackGraphNode],
+            step_nodes_made_unviable: set[AttackGraphNode],
+            step_uncompromised_nodes: set[AttackGraphNode],
+            all_attackers_done: bool
+        ) -> DefenderState:
+        """
+        Build defender state from previous `defender_state` with given
+        args. This is faster than running _create_defender_state every time,
+        since it only adds the 'diff' of the state.
+        It will also set the additional step_* fields for the agent state.
+
+        Args:
+            - defender_state: the old state of the defender to update
+            - step_compromised_nodes: 
+                the nodes compromised since last update
+            - step_enabled_defenses:
+                the defense node enabled since last update
+            - step_nodes_made_unviable:
+                the steps made unviable since last update
+            - step_uncompromised_nodes:
+                steps that were uncompromised
+                (see sim_settings.uncompromise_untraversable_steps)
+        Returns:
+            - an AttackerState based on `attacker_state` updated with the
+              given args
+        """
+
+        # defender step_reward is the sum of uncompromised nodes rewards
+        # minus the sum of all enabled/compromised nodes rewards
+        step_reward = (
+            sum(n.extras.get('reward', 0) for n in step_uncompromised_nodes)
+            - sum(
+                n.extras.get('reward', 0)
+                for n in step_compromised_nodes | step_enabled_defenses
+            )
+        )
+
+        # new defender action surface is old one minus step_enabled_defenses
+        new_action_surface = (
+            defender_state.action_surface - step_enabled_defenses
+        )
+
+        return DefenderState(
+            name=defender_state.name,
+            reward=defender_state.reward + step_reward,
+            action_surface=new_action_surface,
+            step_performed_nodes=step_enabled_defenses,
+            step_action_surface_additions=set(), # no additions for defender
+            step_action_surface_removals=step_enabled_defenses,
+            step_unviable_nodes=step_nodes_made_unviable,
+            step_all_compromised_nodes=step_compromised_nodes,
+            truncated=self.cur_iter > self.max_iter,
+            # terminate defender if all attackers are terminated
+            terminated=all_attackers_done
+        )
+
+    def _reset_agent_states(self) -> dict[str, AgentState]:
+        """Return agent states created from current attack graph state"""
+        agent_states: dict[str, AgentState] = {}
+        for agent_state in self._get_attacker_states():
+            # Create state for attackers
+            agent_states[agent_state.name] = (
+                self._create_attacker_state(
+                    agent_state.name, agent_state.attacker_id
                 )
-
-            elif isinstance(agent, MalSimDefenderState):
-                agent.action_surface = \
-                    query.get_defense_surface(self.attack_graph)
-            else:
-                raise LookupError(f"Agent type {agent.type} not supported")
-
-    def _reset_agents(self):
-        """Reset agent rewards and action surfaces"""
-
-        # Revive all agents
-        self._alive_agents = set(self._agent_states.keys())
-
-        for agent_state in self._get_attacker_agents():
-            # Create a new agent state for the attacker
-            self._agent_states[agent_state.name] = (
-                MalSimAttackerState(agent_state.name, agent_state.attacker_id)
             )
-
-        for agent_state in self._get_defender_agents():
-            # Create a new agent state for the attacker
-            self._agent_states[agent_state.name] = (
-                MalSimDefenderState(agent_state.name)
+        for agent_state in self._get_defender_states():
+            # Create state for defenders
+            agent_states[agent_state.name] = (
+                self._create_defender_state(agent_state.name)
             )
+        return agent_states
 
-        self._init_agent_rewards()
-        self._init_agent_action_surfaces()
-
-    def register_attacker(self, name: str, attacker_id: int):
-        """Register a mal sim attacker agent"""
-        assert name not in self._agent_states, \
-            f"Duplicate agent named {name} not allowed"
-
-        agent_state = MalSimAttackerState(name, attacker_id)
-        self._agent_states[name] = agent_state
-        self._alive_agents.add(name)
-
-    def register_defender(self, name: str):
-        """Register a mal sim defender agent"""
-        assert name not in self._agent_states, \
-            f"Duplicate agent named {name} not allowed"
-
-        agent_state = MalSimDefenderState(name)
-        self._agent_states[name] = agent_state
-        self._alive_agents.add(name)
-
-    @property
-    def agent_states(self) -> dict[str, MalSimAgentStateView]:
-        """Return read only agent state for all dead and alive agents"""
-        return {
-            name: MalSimAgentStateView(agent)
-            for name, agent in self._agent_states.items()
-        }
-
-    def _get_attacker_agents(self) -> list[MalSimAttackerState]:
-        """Return list of mutable attacker agent states of alive attackers"""
+    def _get_attacker_states(self) -> list[AttackerState]:
+        """Return list of current attacker agent states of alive attackers"""
         return [
-            a for a in self._agent_states.values()
+            a for a in self.agent_states.values()
             if a.name in self._alive_agents
-            and isinstance(a, MalSimAttackerState)
+            and isinstance(a, AttackerState)
         ]
 
-    def _get_defender_agents(self) -> list[MalSimDefenderState]:
-        """Return list of mutable defender agent states of alive defenders"""
+    def _get_defender_states(self) -> list[DefenderState]:
+        """Return list of current defender agent states of alive defenders"""
         return [
-            a for a in self._agent_states.values()
+            a for a in self.agent_states.values()
             if a.name in self._alive_agents
-            and isinstance(a, MalSimDefenderState)
+            and isinstance(a, DefenderState)
         ]
 
     def _uncompromise_attack_steps(
         self, attack_steps_to_uncompromise: set[AttackGraphNode]
-    ):
+    ) -> set[AttackGraphNode]:
         """Uncompromise nodes for each attacker agent
 
         Go through the nodes in `attack_steps_to_uncompromise` for each
-        attacker agent. If a node is compromised by the attacker agent:
-            - Uncompromise the node and remove rewards for it.
+        attacker agent and uncompromise the nodes given if compromised.
         """
-        for attacker_agent in self._get_attacker_agents():
+        uncompromised_nodes = set()
+        for attacker_agent in self._get_attacker_states():
             attacker = self.attack_graph.attackers[attacker_agent.attacker_id]
-
-            for unviable_node in attack_steps_to_uncompromise:
-                if unviable_node.is_compromised_by(attacker):
-
-                    # Reward is no longer present for attacker
-                    node_reward = unviable_node.extras.get('reward', 0)
-                    attacker_agent.reward -= node_reward
-
-                    # Reward is no longer present for defenders
-                    for defender_agent in self._get_defender_agents():
-                        defender_agent.reward += node_reward
-
-                    # Uncompromise node if requested
-                    attacker.undo_compromise(unviable_node)
+            for node in attack_steps_to_uncompromise:
+                if node.is_compromised_by(attacker):
+                    uncompromised_nodes.add(node)
+                    attacker.undo_compromise(node)
+        return uncompromised_nodes
 
     def _attacker_step(
-        self, agent: MalSimAttackerState, nodes: list[AttackGraphNode]
-    ):
+        self, agent: AttackerState, nodes: list[AttackGraphNode]
+    ) -> set[AttackGraphNode]:
         """Compromise attack step nodes with attacker
 
         Args:
         agent - the agent to compromise nodes with
         nodes - the nodes to compromise
+
+        Returns:
+        - attack step nodes that were compromised by this agent this step
         """
 
-        compromised_nodes = set()
         attacker = self.attack_graph.attackers[agent.attacker_id]
+        step_compromised_nodes = set()
 
         for node in nodes:
             assert node == self.attack_graph.nodes[node.id], (
-                f"{agent.name} tried to enable a node that is not part "
+                f"{agent.name} tried to compromise a node that is not part "
                 "of this simulators attack_graph. Make sure the node "
                 "comes from the agents action surface."
             )
@@ -370,8 +370,7 @@ class MalSimulator():
             if query.is_node_traversable_by_attacker(node, attacker) \
                     and node in agent.action_surface:
                 attacker.compromise(node)
-                agent.reward += node.extras.get('reward', 0)
-                compromised_nodes.add(node)
+                step_compromised_nodes.add(node)
 
                 logger.info(
                     'Attacker agent "%s" compromised "%s"(%d).',
@@ -381,43 +380,32 @@ class MalSimulator():
                 logger.warning("Attacker could not compromise %s",
                                node.full_name)
 
-        # Update attacker action surface
-        attack_surface_additions = query.calculate_attack_surface(
-            attacker, from_nodes = compromised_nodes, skip_compromised = True
-        )
+        return step_compromised_nodes
 
-        # Filter out nodes already in action surface, these are not additions.
-        attack_surface_additions -= agent.action_surface
-        # Also filter out nodes already compromised from the attack surface.
-        # TODO: Make this configurable in the future
-        agent.action_surface -= compromised_nodes
-        agent.step_action_surface_removals |= compromised_nodes
-
-        agent.step_action_surface_additions = attack_surface_additions
-        agent.action_surface |= attack_surface_additions
-        agent.step_performed_nodes = compromised_nodes
-
-        # Terminate attacker if it has nothing left to do
-        terminate = True
-        for node in agent.action_surface:
-            if not node.is_compromised_by(attacker):
-                terminate = False
-                break
-        agent.terminated = terminate
 
     def _defender_step(
-        self, agent: MalSimDefenderState, nodes: list[AttackGraphNode]
-    ):
+        self, agent: DefenderState, nodes: list[AttackGraphNode]
+    ) -> tuple[
+            set[AttackGraphNode],
+            set[AttackGraphNode],
+            set[AttackGraphNode]
+        ]:
         """Enable defense step nodes with defender.
 
         Args:
         agent - the agent to activate defense nodes with
         nodes - the defense step nodes to enable
 
+        Returns:
+        - defense nodes that were enabled this step by this defender
+        - attack step nodes made unviable by those defenses
+        - attack steps node that were uncompromised this step
+          (always empty if uncompromise_untraversable_steps=False)
         """
 
         enabled_defenses = set()
         attack_steps_made_unviable = set()
+        uncompromised_attack_steps = set()
 
         for node in nodes:
             assert node == self.attack_graph.nodes[node.id], (
@@ -444,35 +432,46 @@ class MalSimulator():
                 node.is_viable = False
                 attack_steps_made_unviable |= \
                     apriori.propagate_viability_from_unviable_node(node)
-                agent.reward -= node.extras.get("reward", 0)
                 enabled_defenses.add(node)
                 logger.info(
                     'Defender agent "%s" enabled "%s"(%d).',
                     agent.name, node.full_name, node.id
                 )
 
-        agent.step_performed_nodes = enabled_defenses
-        agent.step_unviable_nodes |= attack_steps_made_unviable
-
-        for defender_agent in self._get_defender_agents():
-            # Remove enabled defenses from all defenders action surface
-            defender_agent.step_action_surface_removals |= enabled_defenses
-            defender_agent.action_surface -= enabled_defenses
-
-        for attacker_agent in self._get_attacker_agents():
-            # Remove attack steps made unviable from all attackers
-            # action surfaces if they were part of it
-            attacker_agent.step_action_surface_removals |= (
-                attacker_agent.action_surface & attack_steps_made_unviable
-            )
-            attacker_agent.action_surface -= attack_steps_made_unviable
-
         if self.sim_settings.uncompromise_untraversable_steps:
-            self._uncompromise_attack_steps(attack_steps_made_unviable)
+            uncompromised_attack_steps = self._uncompromise_attack_steps(
+                attack_steps_made_unviable
+            )
+
+        return (
+            enabled_defenses,
+            attack_steps_made_unviable,
+            uncompromised_attack_steps
+        )
+
+    def register_attacker(self, name: str, attacker_id: int):
+        """Register a mal sim attacker agent and create its state"""
+        assert name not in self.agent_states, \
+            f"Duplicate agent named {name} not allowed"
+
+        self._alive_agents.add(name)
+        agent_state = self._create_attacker_state(name, attacker_id)
+        self.agent_states[name] = agent_state
+        return agent_state
+
+    def register_defender(self, name: str):
+        """Register a mal sim defender agent and create its state"""
+        assert name not in self.agent_states, \
+            f"Duplicate agent named {name} not allowed"
+
+        self._alive_agents.add(name)
+        agent_state = self._create_defender_state(name)
+        self.agent_states[name] = agent_state
+        return agent_state
 
     def step(
         self, actions: dict[str, list[AttackGraphNode]]
-    ) -> dict[str, MalSimAgentStateView]:
+    ) -> dict[str, AgentState]:
         """Take a step in the simulation
 
         Args:
@@ -480,68 +479,93 @@ class MalSimulator():
                   contains the actions for that user.
 
         Returns:
-        - A dictionary containing the agent state views keyed by agent names
+        - A dictionary containing agent states keyed by agent names
         """
         logger.info(
             "Stepping through iteration %d/%d", self.cur_iter, self.max_iter
         )
         logger.debug("Performing actions: %s", actions)
 
-        # Populate these from the results for all agents' actions.
-        all_compromised = set()
-        unviable_nodes = set()
-        all_attackers_terminated = True
+        # Store everything that happened in this step
+        step_enabled_defenses: set[AttackGraphNode] = set()
+        step_compromised_nodes: set[AttackGraphNode] = set()
+        step_uncompromised_nodes: set[AttackGraphNode] = set()
+        step_nodes_made_unviable: set[AttackGraphNode] = set()
 
-        # Prepare agent states for new step
-        for agent_name in self._alive_agents:
-            agent = self._agent_states[agent_name]
-            # Clear action surface removals from previous step to
-            # make sure the old values do not carry over.
-            agent.step_action_surface_removals = set()
-            # All agents share same set of unviable_nodes
-            agent.step_unviable_nodes = unviable_nodes
+        # Store compromised nodes per agent
+        agent_compromised_nodes: dict[str, set[AttackGraphNode]] = {}
 
         # Perform defender actions first
-        for agent in self._get_defender_agents():
-            agent_actions = actions.get(agent.name, [])
-            self._defender_step(agent, agent_actions)
-            # All defenders share the same set of compromised nodes
-            # Which is built from what the attackers do this step
-            agent.step_all_compromised_nodes = all_compromised
+        for defender_state in self._get_defender_states():
+            agent_actions = actions.get(defender_state.name, [])
+            enabled, unviable, uncompromised = (
+                self._defender_step(defender_state, agent_actions)
+            )
+            step_enabled_defenses.update(enabled)
+            step_uncompromised_nodes.update(uncompromised)
+            step_nodes_made_unviable.update(unviable)
 
         # Perform attacker actions afterwards
-        for agent in self._get_attacker_agents():
-            agent_actions = actions.get(agent.name, [])
-            self._attacker_step(agent, agent_actions)
-            all_compromised |= agent.step_performed_nodes
+        for attacker_state in self._get_attacker_states():
+            agent_actions = actions.get(attacker_state.name, [])
+            compromised = self._attacker_step(attacker_state, agent_actions)
+            agent_compromised_nodes[attacker_state.name] = compromised
+            step_compromised_nodes.update(compromised)
 
-            if not agent.terminated:
-                all_attackers_terminated = False
+        # Update attacker states first
+        all_attackers_done = True
+        for old_attacker_state in self._get_attacker_states():
+            new_attacker_state = (
+                self._create_updated_attacker_state(
+                    old_attacker_state,
+                    agent_compromised_nodes[old_attacker_state.name],
+                    step_nodes_made_unviable,
+                    step_uncompromised_nodes
+                )
+            )
+            self.agent_states[old_attacker_state.name] = new_attacker_state
+            if new_attacker_state.truncated or new_attacker_state.terminated:
+                logger.info("Attacker %s is done", new_attacker_state.name)
+                self._alive_agents.remove(new_attacker_state.name)
+            else:
+                all_attackers_done = False
 
-        # Apply defenders negative rewards from compromises this step
-        lost_rewards = sum(n.extras.get("reward", 0) for n in all_compromised)
-        for defender in self._get_defender_agents():
-            defender.reward -= lost_rewards
-
-        if self._alive_agents and all_attackers_terminated:
-            # Terminate all defenders if all attackers are terminated
-            logger.info("All attackers are terminated")
-            for agent in self._agent_states.values():
-                agent.terminated = True
-
-        if self.cur_iter >= self.max_iter:
-            # Truncate all agents when max iter is reached
-            logger.info("Max iteration reached - all agents truncated")
-            for agent in self._agent_states.values():
-                agent.truncated = True
-
-        for agent_name in self._alive_agents.copy():
-            agent = self._agent_states[agent_name]
-            if agent.terminated or agent.truncated:
-                logger.info("Removing agent %s", agent.name)
-                self._alive_agents.remove(agent_name)
+        # Update defender states afterwards
+        for old_defender_state in self._get_defender_states():
+            new_defender_state = (
+                self._create_updated_defender_state(
+                    old_defender_state,
+                    step_compromised_nodes,
+                    step_enabled_defenses,
+                    step_nodes_made_unviable,
+                    step_uncompromised_nodes,
+                    all_attackers_done,
+                )
+            )
+            self.agent_states[old_defender_state.name] = new_defender_state
+            if new_defender_state.truncated or new_defender_state.terminated:
+                logger.info("Defender %s is done", new_defender_state.name)
+                self._alive_agents.remove(new_defender_state.name)
 
         self.cur_iter += 1
+        return self.agent_states
+
+    def reset(
+        self,
+        seed: Optional[int] = None,
+        options: Optional[dict] = None
+    ) -> dict[str, AgentState]:
+        """Reset attack graph, iteration and reinitialize agents"""
+
+        logger.info("Resetting MAL Simulator.")
+        # Reset attack graph
+        self.attack_graph = copy.deepcopy(self.attack_graph_backup)
+        # Reset current iteration
+        self.cur_iter = 0
+        # Revive all agents
+        self._alive_agents = set(self.agent_states.keys())
+        # Reset agents to attack graph state
+        self.agent_states = self._reset_agent_states()
 
         return self.agent_states
 

--- a/tests/agents/test_searchers.py
+++ b/tests/agents/test_searchers.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 from maltoolbox.attackgraph import AttackGraphNode, Attacker
 from maltoolbox.attackgraph.query import calculate_attack_surface
 from maltoolbox.language import LanguageGraph
-from malsim.mal_simulator import AttackerState
 from malsim.agents import BreadthFirstAttacker, DepthFirstAttacker
 
 

--- a/tests/agents/test_searchers.py
+++ b/tests/agents/test_searchers.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 from maltoolbox.attackgraph import AttackGraphNode, Attacker
 from maltoolbox.attackgraph.query import calculate_attack_surface
 from maltoolbox.language import LanguageGraph
-from malsim.mal_simulator import MalSimAgentStateView
+from malsim.mal_simulator import AttackerState
 from malsim.agents import BreadthFirstAttacker, DepthFirstAttacker
 
 
@@ -42,12 +42,9 @@ def test_breadth_first_traversal_simple(dummy_lang_graph: LanguageGraph):
         reached_attack_steps = set(),
         attacker_id = 100)
 
-    # Set up a mock MalSimAgentState
-    agent = MagicMock()
-    agent.action_surface = [node1]
-
-    # Set up MalSimAgentStateView
-    agent_view = MalSimAgentStateView(agent)
+    # Set up AgentState
+    agent_state = MagicMock()
+    agent_state.action_surface = [node1]
 
     # Configure BreadthFirstAttacker
     agent_config = {"seed": 42, "randomize": False}
@@ -59,12 +56,12 @@ def test_breadth_first_traversal_simple(dummy_lang_graph: LanguageGraph):
     actual_order = []
     for _ in expected_order:
         # Get next action
-        action_node = attacker_ai.get_next_action(agent_view)
+        action_node = attacker_ai.get_next_action(agent_state)
         assert action_node is not None, "Action node shouldn't be None"
 
         # Mark node as compromised
         attacker.compromise(action_node)
-        agent.step_action_surface_additions = calculate_attack_surface(
+        agent_state.step_action_surface_additions = calculate_attack_surface(
             attacker, from_nodes=[action_node]
         )
 
@@ -124,12 +121,9 @@ def test_breadth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
         reached_attack_steps = set(),
         attacker_id = 100)
 
-    # Set up a mock MalSimAgentState
-    agent = MagicMock()
-    agent.action_surface = [node1]
-
-    # Set up MalSimAgentStateView
-    agent_view = MalSimAgentStateView(agent)
+    # Set up AgentState
+    agent_state = MagicMock()
+    agent_state.action_surface = [node1]
 
     # Configure BreadthFirstAttacker
     agent_config = {"seed": 42, "randomize": False}
@@ -141,12 +135,12 @@ def test_breadth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
     actual_order = []
     for _ in expected_order:
         # Get next action
-        action_node = attacker_ai.get_next_action(agent_view)
+        action_node = attacker_ai.get_next_action(agent_state)
         assert action_node is not None, "Action node shouldn't be None"
 
         # Mark node as compromised
         attacker.compromise(action_node)
-        agent.step_action_surface_additions = calculate_attack_surface(
+        agent_state.step_action_surface_additions = calculate_attack_surface(
             attacker, from_nodes=[action_node]
         )
 
@@ -207,12 +201,9 @@ def test_depth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
         reached_attack_steps = set(),
         attacker_id = 100)
 
-    # Set up a mock MalSimAgentState
-    agent = MagicMock()
-    agent.action_surface = [node1]
-
-    # Set up MalSimAgentStateView
-    agent_view = MalSimAgentStateView(agent)
+    # Set up AgentState
+    agent_state = MagicMock()
+    agent_state.action_surface = [node1]
 
     # Configure BreadthFirstAttacker
     agent_config = {"seed": 42, "randomize": False}
@@ -224,12 +215,12 @@ def test_depth_first_traversal_complicated(dummy_lang_graph: LanguageGraph):
     actual_order = []
     for _ in expected_order:
         # Get next action
-        action_node = attacker_ai.get_next_action(agent_view)
+        action_node = attacker_ai.get_next_action(agent_state)
         assert action_node is not None, "Action node shouldn't be None"
 
         # Mark node as compromised
         attacker.compromise(action_node)
-        agent.step_action_surface_additions = calculate_attack_surface(
+        agent_state.step_action_surface_additions = calculate_attack_surface(
             attacker, from_nodes=[action_node]
         )
 

--- a/tests/envs/test_vectorized_obs_mal_simulator.py
+++ b/tests/envs/test_vectorized_obs_mal_simulator.py
@@ -1,7 +1,7 @@
 """Test MalSimulator class"""
 
 from maltoolbox.attackgraph import AttackGraph, Attacker
-from malsim.mal_simulator import MalSimulator, AttackerState
+from malsim.mal_simulator import MalSimulator
 from malsim.envs import MalSimVectorizedObsEnv
 from malsim.scenario import load_scenario
 

--- a/tests/envs/test_vectorized_obs_mal_simulator.py
+++ b/tests/envs/test_vectorized_obs_mal_simulator.py
@@ -1,7 +1,7 @@
 """Test MalSimulator class"""
 
 from maltoolbox.attackgraph import AttackGraph, Attacker
-from malsim.mal_simulator import MalSimulator, MalSimAttackerState
+from malsim.mal_simulator import MalSimulator, AttackerState
 from malsim.envs import MalSimVectorizedObsEnv
 from malsim.scenario import load_scenario
 
@@ -110,10 +110,10 @@ def test_step_deterministic(
     obs2 = {}
 
     # Run 1
-    sim.reset(seed=123)
+    obs, infos = sim.reset(seed=123)
     for _ in range(10):
         attacker_node = next(
-            n for n in sim.get_agent_state('test_attacker').action_surface
+            n for n in sim.sim.agent_states['test_attacker'].action_surface
             if not n.is_compromised()
         )
         attacker_action = (1, sim.node_to_index(attacker_node))
@@ -125,7 +125,7 @@ def test_step_deterministic(
     sim.reset(seed=123)
     for _ in range(10):
         attacker_node = next(
-            n for n in sim.get_agent_state('test_attacker').action_surface
+            n for n in sim.sim.agent_states['test_attacker'].action_surface
             if not n.is_compromised()
         )
         attacker_action = (1, sim.node_to_index(attacker_node))
@@ -199,62 +199,6 @@ def test_create_blank_observation_actionability_given(
             assert actionable
         else:
             assert not actionable
-
-def test_step(corelang_lang_graph, model):
-    attack_graph = AttackGraph(corelang_lang_graph, model)
-    entry_point = attack_graph.get_node_by_full_name('OS App:fullAccess')
-
-    attacker = Attacker(
-        'attacker1',
-        reached_attack_steps = {entry_point},
-        entry_points = {entry_point},
-        attacker_id = 100)
-    attack_graph.add_attacker(attacker, attacker.id)
-    env = MalSimVectorizedObsEnv(MalSimulator(attack_graph))
-
-    # Refresh attack graph reference to the one deepcopied during the reset
-    attack_graph = env.sim.attack_graph
-
-    agent_info = MalSimAttackerState(attacker.name, attacker.id)
-
-    # Can not attack the notPresent step
-    defense_step = attack_graph\
-        .get_node_by_full_name('OS App:notPresent')
-    actions = env.sim._attacker_step(agent_info, {defense_step})
-    assert not actions
-    assert not agent_info.step_action_surface_additions
-
-    attack_step = attack_graph.get_node_by_full_name('OS App:attemptRead')
-
-    # Action needs to be in action surface to be an allowed action
-    agent_info.action_surface = {attack_step}
-
-    # Since action is in attack surface and since it is traversable,
-    # action will be performed.
-    env.sim._attacker_step(agent_info, {attack_step})
-    assert agent_info.step_performed_nodes == {attack_step}
-    assert agent_info.step_action_surface_additions == attack_step.children
-
-
-def test_malsimulator_defender_step(corelang_lang_graph, model):
-    attack_graph = AttackGraph(corelang_lang_graph, model)
-    env = MalSimVectorizedObsEnv(MalSimulator(attack_graph))
-
-    agent_name = "defender1"
-    env.register_defender(agent_name)
-    env.reset()
-
-    defender_agent = env.sim._agent_states[agent_name]
-    defense_step = env.sim.attack_graph.get_node_by_full_name(
-        'OS App:notPresent')
-    env.sim._defender_step(defender_agent, {defense_step})
-    assert defender_agent.step_performed_nodes == {defense_step}
-
-    # Can not defend attack_step
-    attack_step = env.sim.attack_graph.get_node_by_full_name(
-        'OS App:attemptUseVulnerability')
-    env.sim._defender_step(defender_agent, {attack_step})
-    assert not defender_agent.step_performed_nodes
 
 
 def test_malsimulator_observe_attacker():

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -3,7 +3,7 @@
 from maltoolbox.attackgraph import AttackGraphNode, AttackGraph, Attacker
 from malsim.mal_simulator import MalSimulator
 
-from malsim.scenario import load_scenario
+from malsim.scenario import load_scenario, create_simulator_from_scenario
 
 def test_init(corelang_lang_graph, model):
     attack_graph = AttackGraph(corelang_lang_graph, model)
@@ -54,11 +54,12 @@ def test_reset(corelang_lang_graph, model):
 
 def test_register_agent_attacker(corelang_lang_graph, model):
     attack_graph = AttackGraph(corelang_lang_graph, model)
+    attack_graph.attach_attackers()
     sim = MalSimulator(attack_graph)
 
-    attacker = 1
+    attacker_id = next(iter(attack_graph.attackers))
     agent_name = "attacker1"
-    sim.register_attacker(agent_name, attacker)
+    sim.register_attacker(agent_name, attacker_id)
 
     assert agent_name in sim.agent_states
     assert agent_name in sim.agent_states
@@ -80,11 +81,10 @@ def test_register_agent_action_surface(corelang_lang_graph, model):
     sim = MalSimulator(attack_graph)
 
     agent_name = "defender1"
-    sim.register_defender(agent_name)
+    agent_state = sim.register_defender(agent_name)
+    sim.reset()
 
-    sim._init_agent_action_surfaces()
-    action_surface = sim.agent_states[agent_name].action_surface
-    for node in action_surface:
+    for node in agent_state.action_surface:
         assert node.is_available_defense()
 
 
@@ -107,14 +107,15 @@ def test_simulator_initialize_agents(corelang_lang_graph, model):
 
 
 def test_get_agents():
-    """Test _get_attacker_agents and _get_defender_agents"""
+    """Test get_attacker_states and get_defender_states"""
 
-    ag, _ = load_scenario('tests/testdata/scenarios/simple_scenario.yml')
-    sim = MalSimulator(ag)
+    # Scenario defines defender and attacker agent named Defender1/Attacker1
+    sim, _ = create_simulator_from_scenario(
+        'tests/testdata/scenarios/simple_scenario.yml'
+    )
     sim.reset()
-
-    sim._get_attacker_agents() == ['attacker']
-    sim._get_defender_agents() == ['defender']
+    assert [s.name for s in sim._get_attacker_states()] == ['Attacker1']
+    assert [s.name for s in sim._get_defender_states()] == ['Defender1']
 
 
 def test_attacker_step(corelang_lang_graph, model):
@@ -132,18 +133,16 @@ def test_attacker_step(corelang_lang_graph, model):
 
     sim.register_attacker(attacker.name, attacker.id)
     sim.reset()
-    attacker_agent = sim._agent_states[attacker.name]
+    attacker_agent = sim.agent_states[attacker.name]
 
     # Can not attack the notPresent step
     defense_step = sim.attack_graph.get_node_by_full_name('OS App:notPresent')
-    actions = sim._attacker_step(attacker_agent, {defense_step})
-    assert not actions
-    assert not attacker_agent.step_action_surface_additions
+    compromised = sim._attacker_step(attacker_agent, {defense_step})
+    assert not compromised
 
     attack_step = sim.attack_graph.get_node_by_full_name('OS App:attemptRead')
-    sim._attacker_step(attacker_agent, {attack_step})
-    assert attacker_agent.step_performed_nodes  == {attack_step}
-    assert attacker_agent.step_action_surface_additions == attack_step.children
+    compromised = sim._attacker_step(attacker_agent, {attack_step})
+    assert compromised  == {attack_step}
 
 
 def test_defender_step(corelang_lang_graph, model):
@@ -154,17 +153,17 @@ def test_defender_step(corelang_lang_graph, model):
     sim.register_defender(defender_name)
     sim.reset()
 
-    defender_agent = sim._agent_states[defender_name]
+    defender_agent = sim.agent_states[defender_name]
     defense_step = sim.attack_graph.get_node_by_full_name(
         'OS App:notPresent')
-    sim._defender_step(defender_agent, {defense_step})
-    assert defender_agent.step_performed_nodes == {defense_step}
+    performed, _, _ = sim._defender_step(defender_agent, [defense_step])
+    assert performed == {defense_step}
 
     # Can not defend attack_step
     attack_step = sim.attack_graph.get_node_by_full_name(
         'OS App:attemptUseVulnerability')
-    sim._defender_step(defender_agent, {attack_step})
-    assert not defender_agent.step_performed_nodes
+    performed, _, _ = sim._defender_step(defender_agent, [attack_step])
+    assert not performed
 
 
 def test_agent_state_views_simple(corelang_lang_graph, model):
@@ -303,35 +302,32 @@ def test_step_attacker_defender_action_surface_updates():
     sim.register_attacker(attacker_agent_id, 1)
     sim.register_defender(defender_agent_id)
 
-    sim.reset()
-
-    attacker_agent = sim.agent_states[attacker_agent_id]
-    defender_agent = sim.agent_states[defender_agent_id]
+    states = sim.reset()
 
     # Run step() with action crafted in test
     attacker_step = sim.attack_graph.get_node_by_full_name('User:3:compromise')
-    assert attacker_step in attacker_agent.action_surface
+    assert attacker_step in states[attacker_agent_id].action_surface
 
     defender_step = sim.attack_graph.get_node_by_full_name('User:3:notPresent')
-    assert defender_step in defender_agent.action_surface
+    assert defender_step in states[defender_agent_id].action_surface
 
     actions = {
-        attacker_agent.name: [attacker_step],
-        defender_agent.name: [defender_step]
+        attacker_agent_id: [attacker_step],
+        defender_agent_id: [defender_step]
     }
 
-    sim.step(actions)
+    state = sim.step(actions)
 
     # Make sure no nodes added to action surface
-    assert not attacker_agent.step_action_surface_additions
-    assert not defender_agent.step_action_surface_additions
+    assert not state[attacker_agent_id].step_action_surface_additions
+    assert not state[defender_agent_id].step_action_surface_additions
 
     # Make sure the steps are removed from the action surfaces
-    assert attacker_step in attacker_agent.step_action_surface_removals
-    assert defender_step in defender_agent.step_action_surface_removals
+    assert attacker_step in state[attacker_agent_id].step_action_surface_removals
+    assert defender_step in state[defender_agent_id].step_action_surface_removals
 
-    assert attacker_step not in attacker_agent.action_surface
-    assert defender_step not in defender_agent.action_surface
+    assert attacker_step not in state[attacker_agent_id].action_surface
+    assert defender_step not in state[defender_agent_id].action_surface
 
 
 def test_default_simulator_default_settings_eviction():


### PR DESCRIPTION
This PR introduces a more functional coding style into the simulator. It does not change any functionality and the goal was to not break any of the public APIs, which I hope I didn't.

AgentState objects are not long living states anymore, but only valid for the last step and recreated every time the simulator takes a new step. I think this approach is more elegant in some ways (all agent state changes happen in one place). Basically it gets easier to keep track on the current state of the simulator. 

- Rename MalSimAgentState -> AgentState
- Remove MalSimAgentStateView
  - There is no longer a mutable agent state, just an immutable one

PROS
  - This is safer: nobody will change agent states by mistake
  - This is easier to follow: all changes to the agent state must be done in one place
  - This removes the need for an AgentStateView
  - This is good for the future if we want to let users give states to the simulator to move back/forth to old steps.

CONS:
  - Extra code to rebuild the whole dataclass object every step
