### PR TITLE
Create methods to calculate rewards and termination and use those instead of calculating in place

### DIFF
--- a/malsim/mal_simulator.py
+++ b/malsim/mal_simulator.py
@@ -488,7 +488,7 @@ class MalSimulator():
             attacker_state: MalSimAttackerState,
             step_agent_compromised_nodes: set[AttackGraphNode],
         ):
-        """Defender is rewarded for each compromised node"""
+        """Attacker is rewarded for each compromised node"""
         return attacker_state.reward + sum(
             n.extras.get("reward", 0)
             for n in step_agent_compromised_nodes
@@ -559,7 +559,7 @@ class MalSimulator():
             )
             step_compromised_nodes |= compromised
 
-            # Calculate attackers rewards, truncation and terminations
+            # Calculate attacker reward and termination
             attacker_state.reward = self._attacker_step_reward(
                 attacker_state, attacker_state.step_performed_nodes,
             )

--- a/tests/envs/test_vectorized_obs_mal_simulator.py
+++ b/tests/envs/test_vectorized_obs_mal_simulator.py
@@ -1,7 +1,7 @@
 """Test MalSimulator class"""
 
 from maltoolbox.attackgraph import AttackGraph, Attacker
-from malsim.mal_simulator import MalSimulator, MalSimAttackerState
+from malsim.mal_simulator import MalSimulator
 from malsim.envs import MalSimVectorizedObsEnv
 from malsim.scenario import load_scenario
 

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -129,8 +129,7 @@ def test_attacker_step(corelang_lang_graph, model):
     attack_graph.add_attacker(attacker, attacker.id)
     sim = MalSimulator(attack_graph)
 
-    sim.register_attacker(attacker.name,
-        attacker.id)
+    sim.register_attacker(attacker.name, attacker.id)
     sim.reset()
     attacker_agent = sim._agent_states[attacker.name]
 
@@ -188,16 +187,21 @@ def test_agent_state_views_simple(corelang_lang_graph, model):
     sim = MalSimulator(attack_graph)
     attacker_name = 'attacker'
     defender_name = 'defender'
-    sim.register_attacker(attacker_name,
-        attacker.id)
+    sim.register_attacker(attacker_name, attacker.id)
     sim.register_defender(defender_name)
 
     # Evaluate the agent state views after reset
     state_views = sim.reset()
     asv = state_views['attacker']
     dsv = state_views['defender']
-    assert asv.step_performed_nodes == set()
-    assert dsv.step_performed_nodes == set()
+    assert asv.step_performed_nodes == set(
+        # Will contain all pre compromised attack steps
+        asv.attacker.reached_attack_steps
+    )
+    assert dsv.step_performed_nodes == set(
+        # Will contain all pre enabled defenses
+        n for n in sim.attack_graph.nodes.values() if n.is_enabled_defense()
+    )
     assert len(asv.action_surface) == 6
     assert len(dsv.action_surface) == 21
     assert dsv.step_action_surface_additions == set()

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -138,12 +138,10 @@ def test_attacker_step(corelang_lang_graph, model):
     defense_step = sim.attack_graph.get_node_by_full_name('OS App:notPresent')
     actions = sim._attacker_step(attacker_agent, {defense_step})
     assert not actions
-    assert not attacker_agent.step_action_surface_additions
 
     attack_step = sim.attack_graph.get_node_by_full_name('OS App:attemptRead')
-    sim._attacker_step(attacker_agent, {attack_step})
-    assert attacker_agent.step_performed_nodes  == {attack_step}
-    assert attacker_agent.step_action_surface_additions == attack_step.children
+    actions = sim._attacker_step(attacker_agent, {attack_step})
+    assert actions  == {attack_step}
 
 
 def test_defender_step(corelang_lang_graph, model):
@@ -157,15 +155,16 @@ def test_defender_step(corelang_lang_graph, model):
     defender_agent = sim._agent_states[defender_name]
     defense_step = sim.attack_graph.get_node_by_full_name(
         'OS App:notPresent')
-    sim._defender_step(defender_agent, {defense_step})
-    assert defender_agent.step_performed_nodes == {defense_step}
+    enabled, made_unviable = sim._defender_step(defender_agent, {defense_step})
+    assert enabled ==  {defense_step}
+    assert made_unviable
 
     # Can not defend attack_step
     attack_step = sim.attack_graph.get_node_by_full_name(
         'OS App:attemptUseVulnerability')
-    sim._defender_step(defender_agent, {attack_step})
-    assert not defender_agent.step_performed_nodes
-
+    enabled, made_unviable = sim._defender_step(defender_agent, {attack_step})
+    assert enabled == set()
+    assert not made_unviable
 
 def test_agent_state_views_simple(corelang_lang_graph, model):
 


### PR DESCRIPTION
Create `_attacker_step_reward`, `_defender_step_reward`, `_attacker_is_terminated`, `_defender_is_terminated`.

This came up after discussions in the MAL Plenary, and the reasoning is to make it easier for users to override this logic in particular instead of rewriting bigger part of the logic. (@sandorstormen is the one who brought it up).

As a bonus it also makes it clearer how rewards are set each step.
Before they were set in place in attacker_step and defender_step, but now the method is called in step.

I think we should do the same for all parts of the agent state calculations but I kept this PR limited to rewards and termination.
