### PR TITLE
Immutable agent state

### DIFF
--- a/malsim/agents/decision_agent.py
+++ b/malsim/agents/decision_agent.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Optional, Any
 from abc import ABC, abstractmethod
 
 if TYPE_CHECKING:
-    from ..mal_simulator import MalSimAgentStateView
+    from ..mal_simulator import MalSimAgentState
     from maltoolbox.attackgraph import AttackGraphNode
 
 class DecisionAgent(ABC):
@@ -13,7 +13,7 @@ class DecisionAgent(ABC):
     @abstractmethod
     def get_next_action(
         self,
-        agent_state: MalSimAgentStateView,
+        agent_state: MalSimAgentState,
         **kwargs: Any
     ) -> Optional[AttackGraphNode]:
         """

--- a/malsim/agents/heuristic_agent.py
+++ b/malsim/agents/heuristic_agent.py
@@ -9,7 +9,7 @@ from .decision_agent import DecisionAgent
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
-    from ..mal_simulator import MalSimAgentStateView
+    from ..mal_simulator import MalSimAgentState, MalSimDefenderState
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class DefendCompromisedDefender(DecisionAgent):
         self.compromised_nodes: set[AttackGraphNode] = set()
 
     def get_next_action(
-        self, agent_state: MalSimAgentStateView, **kwargs: Any
+        self, agent_state: MalSimDefenderState, **kwargs: Any
     ) -> Optional[AttackGraphNode]:
 
         """Return an action that disables a compromised node"""
@@ -89,7 +89,7 @@ class DefendFutureCompromisedDefender(DecisionAgent):
         self.compromised_nodes: set[AttackGraphNode] = set()
 
     def get_next_action(
-        self, agent_state: MalSimAgentStateView, **kwargs: Any
+        self, agent_state: MalSimDefenderState, **kwargs: Any
     ) -> Optional[AttackGraphNode]:
 
         """Return an action that disables a compromised node"""

--- a/malsim/agents/heuristic_agent.py
+++ b/malsim/agents/heuristic_agent.py
@@ -5,15 +5,13 @@ import math
 
 import numpy as np
 
-from .decision_agent import DecisionAgent
-
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
-    from ..mal_simulator import MalSimAgentState, MalSimDefenderState
+    from ..mal_simulator import MalSimDefenderState
 
 logger = logging.getLogger(__name__)
 
-class DefendCompromisedDefender(DecisionAgent):
+class DefendCompromisedDefender:
     """A defender that defends compromised assets using notPresent"""
 
     def __init__(self, agent_config: dict[str, Any], **_: Any):
@@ -71,7 +69,7 @@ class DefendCompromisedDefender(DecisionAgent):
         return selected_node
 
 
-class DefendFutureCompromisedDefender(DecisionAgent):
+class DefendFutureCompromisedDefender:
     """A defender that defends compromised assets using notPresent"""
 
     def __init__(self, agent_config: dict[str, Any], **_: Any):

--- a/malsim/agents/keyboard_input.py
+++ b/malsim/agents/keyboard_input.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Optional, Any
 
 from .decision_agent import DecisionAgent
-from ..mal_simulator import MalSimAgentStateView
+from ..mal_simulator import MalSimAgentState
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
@@ -19,7 +19,7 @@ class KeyboardAgent(DecisionAgent):
 
     def get_next_action(
             self,
-            agent_state: MalSimAgentStateView,
+            agent_state: MalSimAgentState,
             **kwargs: Any
         ) -> Optional[AttackGraphNode]:
         """Compute action from action_surface"""

--- a/malsim/agents/passive_agent.py
+++ b/malsim/agents/passive_agent.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Any
 
 from .decision_agent import DecisionAgent
-from ..mal_simulator import MalSimAgentStateView
+from ..mal_simulator import MalSimAgentState
 
 if TYPE_CHECKING:
-    from ..mal_simulator import MalSimAgentStateView
+    from ..mal_simulator import MalSimAgentState
     from maltoolbox.attackgraph import AttackGraphNode
 
 class PassiveAgent(DecisionAgent):
@@ -16,7 +16,7 @@ class PassiveAgent(DecisionAgent):
 
     def get_next_action(
         self,
-        agent_state: MalSimAgentStateView,
+        agent_state: MalSimAgentState,
         **kwargs: Any
     ) -> Optional[AttackGraphNode]:
         # A passive agent never does anything

--- a/malsim/agents/random_agent.py
+++ b/malsim/agents/random_agent.py
@@ -6,7 +6,7 @@ from .decision_agent import DecisionAgent
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
-    from ..mal_simulator import MalSimAgentStateView
+    from ..mal_simulator import MalSimAgentState
 
 class RandomAgent(DecisionAgent):
     """An agent that selects random actions"""
@@ -16,7 +16,7 @@ class RandomAgent(DecisionAgent):
         self.rng = random.Random(seed)
 
     def get_next_action(
-        self, agent_state: MalSimAgentStateView, **kwargs: Any
+        self, agent_state: MalSimAgentState, **kwargs: Any
     ) -> Optional[AttackGraphNode]:
         """Return a random node from the action surface"""
         possible_choices = list(agent_state.action_surface)

--- a/malsim/agents/searchers.py
+++ b/malsim/agents/searchers.py
@@ -6,7 +6,7 @@ from collections import deque
 from typing import Optional, TYPE_CHECKING, Any
 
 from .decision_agent import DecisionAgent
-from ..mal_simulator import MalSimAgentStateView
+from ..mal_simulator import MalSimAgentState
 
 if TYPE_CHECKING:
     from maltoolbox.attackgraph import AttackGraphNode
@@ -47,7 +47,7 @@ class BreadthFirstAttacker(DecisionAgent):
         self._started = False
 
     def get_next_action(
-        self, agent_state: MalSimAgentStateView, **kwargs: Any
+        self, agent_state: MalSimAgentState, **kwargs: Any
     ) -> Optional[AttackGraphNode]:
         """Receive the next action according to agent policy (bfs/dfs)"""
 

--- a/malsim/agents/searchers.py
+++ b/malsim/agents/searchers.py
@@ -52,11 +52,11 @@ class BreadthFirstAttacker(DecisionAgent):
         """Receive the next action according to agent policy (bfs/dfs)"""
 
         self._update_targets(
-            new_nodes=(
+            new_nodes=set(
                 agent_state.step_action_surface_additions
                 if self._started else agent_state.action_surface
             ),
-            disabled_nodes=(
+            disabled_nodes=set(
                 agent_state.step_action_surface_removals |
                 agent_state.step_performed_nodes
             )

--- a/malsim/envs/base_classes.py
+++ b/malsim/envs/base_classes.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 from maltoolbox.attackgraph import AttackGraphNode
-from ..mal_simulator import MalSimulator, MalSimAgentStateView
+from ..mal_simulator import MalSimulator, MalSimAgentState
 
 class MalSimEnv(ABC):
 
@@ -32,7 +32,7 @@ class MalSimEnv(ABC):
         ) -> None:
         self.sim.register_defender(defender_name)
 
-    def get_agent_state(self, agent_name: str) -> MalSimAgentStateView:
+    def get_agent_state(self, agent_name: str) -> MalSimAgentState:
         return self.sim.agent_states[agent_name]
 
     def render(self) -> None:

--- a/malsim/envs/malsim_vectorized_obs_env.py
+++ b/malsim/envs/malsim_vectorized_obs_env.py
@@ -20,7 +20,7 @@ from maltoolbox.attackgraph import AttackGraphNode
 from ..mal_simulator import (
     MalSimulator,
     AgentType,
-    MalSimAgentStateView,
+    MalSimAgentState,
     MalSimAttackerState,
     MalSimDefenderState
 )
@@ -102,7 +102,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         """Required by ParallelEnv"""
         return list(self.sim._agent_states.keys())
 
-    def get_agent_state(self, agent_name: str) -> MalSimAgentStateView:
+    def get_agent_state(self, agent_name: str) -> MalSimAgentState:
         return self.sim.agent_states[agent_name]
 
     def _create_blank_observation(
@@ -216,7 +216,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         }
         return np_obs
 
-    def create_action_mask(self, agent_state: MalSimAgentStateView) -> dict[str, Any]:
+    def create_action_mask(self, agent_state: MalSimAgentState) -> dict[str, Any]:
         """
         Create an action mask for an agent based on its action_surface.
 
@@ -228,18 +228,18 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         """
 
         available_actions = [0] * len(self.sim.attack_graph.nodes)
-        can_wait = 1 if agent_state.type == AgentType.DEFENDER else 0
+        can_wait = 1 if isinstance(agent_state, MalSimDefenderState) else 0
         can_act = 0
 
         for node in agent_state.action_surface:
 
-            if agent_state.type == AgentType.DEFENDER:
+            if isinstance(agent_state, MalSimDefenderState):
                 # Defender can act on its whole action surface
                 index = self._id_to_index[node.id]
                 available_actions[index] = 1
                 can_act = 1
 
-            if agent_state.type == AgentType.ATTACKER:
+            if isinstance(agent_state, MalSimAttackerState):
                 # Attacker can only act on nodes that are not compromised
 
                 if node not in agent_state.performed_nodes:
@@ -424,7 +424,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         agent = self.sim.agent_states[defender_name]
         self._init_agent(agent)
 
-    def _init_agent(self, agent: MalSimAgentStateView) -> None:
+    def _init_agent(self, agent: MalSimAgentState) -> None:
         # Fill dicts with env specific agent obs/infos
         self._agent_observations[agent.name] = \
             self._create_blank_observation()
@@ -545,11 +545,11 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         logger.debug("Disable:\n\t%s", [n.full_name for n in disabled_nodes])
 
         for agent in self.sim.agent_states.values():
-            if agent.type == AgentType.ATTACKER:
+            if isinstance(agent, MalSimAttackerState):
                 self._update_attacker_obs(
                     compromised_nodes, disabled_nodes, agent
                 )
-            elif agent.type == AgentType.DEFENDER:
+            elif isinstance(agent, MalSimDefenderState):
                 self._update_defender_obs(
                     compromised_nodes, disabled_nodes, agent
                 )

--- a/malsim/envs/malsim_vectorized_obs_env.py
+++ b/malsim/envs/malsim_vectorized_obs_env.py
@@ -513,7 +513,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
             "Attack graph in simulator needs to have a model attached to it"
         )
 
-        pre_enabled_nodes = set()
+        pre_enabled_nodes: set[AttackGraphNode] = set()
         for agent in self.sim.agent_states.values():
             # Reset observation and action mask for agents
             self._agent_observations[agent.name] = \
@@ -583,7 +583,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         disabled_nodes = next(iter(states.values())).step_unviable_nodes
 
         self._update_agent_infos() # Update action masks
-        self._update_observations(all_actioned, disabled_nodes)
+        self._update_observations(all_actioned, set(disabled_nodes))
 
         observations = self._agent_observations
         rewards = {}

--- a/malsim/envs/malsim_vectorized_obs_env.py
+++ b/malsim/envs/malsim_vectorized_obs_env.py
@@ -592,7 +592,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
         infos = self._agent_infos
 
         for agent in self.sim.agent_states.values():
-            rewards[agent.name] = agent.reward
+            rewards[agent.name] = self.sim.agent_reward(agent.name)
             terminations[agent.name] = self.sim.agent_is_terminated(agent.name)
             truncations[agent.name] = self.sim.done()
 

--- a/malsim/envs/malsim_vectorized_obs_env.py
+++ b/malsim/envs/malsim_vectorized_obs_env.py
@@ -19,7 +19,6 @@ from maltoolbox.attackgraph import AttackGraphNode
 
 from ..mal_simulator import (
     MalSimulator,
-    AgentType,
     MalSimAgentState,
     MalSimAttackerState,
     MalSimDefenderState
@@ -594,7 +593,7 @@ class MalSimVectorizedObsEnv(ParallelEnv): # type: ignore
 
         for agent in self.sim.agent_states.values():
             rewards[agent.name] = agent.reward
-            terminations[agent.name] = agent.terminated
-            truncations[agent.name] = agent.truncated
+            terminations[agent.name] = self.sim.agent_is_terminated(agent.name)
+            truncations[agent.name] = self.sim.done()
 
         return observations, rewards, terminations, truncations, infos

--- a/malsim/mal_simulator.py
+++ b/malsim/mal_simulator.py
@@ -290,7 +290,7 @@ class MalSimulator():
                 )
         return traversable
 
-    def agent_reward(self, agent_name) -> float:
+    def agent_reward(self, agent_name: str) -> float:
         """Get an agents current reward"""
         return self._agent_rewards.get(agent_name, 0)
 
@@ -539,7 +539,7 @@ class MalSimulator():
     def _create_defender_state(self, name: str) -> MalSimDefenderState:
         """Create a new defender state, initialize values"""
 
-        compromised_steps = set()
+        compromised_steps: set[AttackGraphNode] = set()
         for attacker_state in self._get_attacker_agents():
             compromised_steps |= attacker_state.performed_nodes
 

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -1,6 +1,6 @@
 from maltoolbox.attackgraph import AttackGraph
 from maltoolbox.language import LanguageGraph
-from malsim.mal_simulator import MalSimAgentState, MalSimulator
+from malsim.mal_simulator import MalSimulator, MalSimDefenderState
 from malsim.agents import (
     DefendCompromisedDefender,
     DefendFutureCompromisedDefender,
@@ -73,6 +73,7 @@ def test_defend_compromised_defender(
     node2.extras['reward'] = 10
 
     # Get next action
+    assert isinstance(agent_state, MalSimDefenderState)
     action_node = defender_ai.get_next_action(agent_state)
     assert action_node is not None, "Action node shouldn't be None"
     assert action_node.id == node2.id
@@ -157,6 +158,7 @@ def test_defend_future_compromised_defender(
     defender_ai = DefendFutureCompromisedDefender(agent_config)
 
     # Should pick node 2 either way
+    assert isinstance(agent_state, MalSimDefenderState)
     action_node = defender_ai.get_next_action(agent_state)
     assert action_node is not None, "Action node shouldn't be None"
     assert action_node.id == node2.id

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -1,6 +1,6 @@
 from maltoolbox.attackgraph import AttackGraph
 from maltoolbox.language import LanguageGraph
-from malsim.mal_simulator import MalSimAgentStateView, MalSimulator
+from malsim.mal_simulator import MalSimAgentState, MalSimulator
 from malsim.agents import (
     DefendCompromisedDefender,
     DefendFutureCompromisedDefender,
@@ -63,7 +63,6 @@ def test_defend_compromised_defender(
     # Set up a defender
     sim.register_defender('def_comp')
     agent_state = sim.agent_states['def_comp']
-    agent_view = MalSimAgentStateView(agent_state)
 
     # Configure BreadthFirstAttacker
     agent_config = {"seed": 42, "randomize": False}
@@ -74,7 +73,7 @@ def test_defend_compromised_defender(
     node2.extras['reward'] = 10
 
     # Get next action
-    action_node = defender_ai.get_next_action(agent_view)
+    action_node = defender_ai.get_next_action(agent_state)
     assert action_node is not None, "Action node shouldn't be None"
     assert action_node.id == node2.id
 
@@ -83,7 +82,7 @@ def test_defend_compromised_defender(
     node2.extras['reward'] = 100
 
     # Get next action
-    action_node = defender_ai.get_next_action(agent_view)
+    action_node = defender_ai.get_next_action(agent_state)
     assert action_node is not None, "Action node shouldn't be None"
     assert action_node.id == node1.id
 
@@ -152,14 +151,13 @@ def test_defend_future_compromised_defender(
     # Set up a defender
     sim.register_defender('def_future_comp')
     agent_state = sim.agent_states['def_future_comp']
-    agent_view = MalSimAgentStateView(agent_state)
 
     # Configure BreadthFirstAttacker
     agent_config = {"seed": 42, "randomize": False}
     defender_ai = DefendFutureCompromisedDefender(agent_config)
 
     # Should pick node 2 either way
-    action_node = defender_ai.get_next_action(agent_view)
+    action_node = defender_ai.get_next_action(agent_state)
     assert action_node is not None, "Action node shouldn't be None"
     assert action_node.id == node2.id
 

--- a/tests/agents/test_searchers.py
+++ b/tests/agents/test_searchers.py
@@ -55,7 +55,8 @@ def test_breadth_first_traversal_simple(
         assert action_node
 
         # Get next action
-        sim.step({'bfs': [action_node]})
+        states = sim.step({'bfs': [action_node]})
+        agent_state = states['bfs']
 
         # Store the ID for verification
         actual_order.append(next(iter(agent_state.step_performed_nodes)).id)
@@ -130,7 +131,8 @@ def test_breadth_first_traversal_complicated(
         assert action_node
 
         # Get next action
-        sim.step({'bfs': [action_node]})
+        states = sim.step({'bfs': [action_node]})
+        agent_state = states['bfs']
 
         # Store the ID for verification
         actual_order.append(next(iter(agent_state.step_performed_nodes)).id)
@@ -203,7 +205,8 @@ def test_depth_first_traversal_complicated(
         assert action_node
 
         # Get next action
-        sim.step({'dfs': [action_node]})
+        states = sim.step({'dfs': [action_node]})
+        agent_state = states['dfs']
 
         # Store the ID for verification
         actual_order.append(next(iter(agent_state.step_performed_nodes)).id)

--- a/tests/agents/test_searchers.py
+++ b/tests/agents/test_searchers.py
@@ -1,6 +1,6 @@
 from maltoolbox.attackgraph import AttackGraph
 from maltoolbox.language import LanguageGraph
-from malsim.mal_simulator import MalSimulator, MalSimAgentStateView
+from malsim.mal_simulator import MalSimulator, MalSimAgentState
 from malsim.agents import BreadthFirstAttacker, DepthFirstAttacker
 
 
@@ -51,8 +51,7 @@ def test_breadth_first_traversal_simple(
     actual_order = []
     for _ in expected_order:
         # Get next action
-        agent_view = MalSimAgentStateView(agent_state)
-        action_node = attacker_ai.get_next_action(agent_view)
+        action_node = attacker_ai.get_next_action(agent_state)
         assert action_node
 
         # Get next action
@@ -127,8 +126,7 @@ def test_breadth_first_traversal_complicated(
     actual_order = []
     for _ in expected_order:
         # Get next action
-        agent_view = MalSimAgentStateView(agent_state)
-        action_node = attacker_ai.get_next_action(agent_view)
+        action_node = attacker_ai.get_next_action(agent_state)
         assert action_node
 
         # Get next action

--- a/tests/agents/test_searchers.py
+++ b/tests/agents/test_searchers.py
@@ -1,6 +1,6 @@
 from maltoolbox.attackgraph import AttackGraph
 from maltoolbox.language import LanguageGraph
-from malsim.mal_simulator import MalSimulator, MalSimAgentState
+from malsim.mal_simulator import MalSimulator
 from malsim.agents import BreadthFirstAttacker, DepthFirstAttacker
 
 

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -73,8 +73,8 @@ def test_bfs_vs_bfs_state_and_reward() -> None:
         if defender_node and defender_node in defender_state.step_performed_nodes:
             defender_actions.append(defender_node.full_name)
 
-        total_reward_defender += defender_state.reward
-        total_reward_attacker += attacker_state.reward
+        total_reward_defender += sim.agent_reward(defender_state.name)
+        total_reward_attacker += sim.agent_reward(attacker_state.name)
 
     assert sim.cur_iter == 44
 
@@ -150,8 +150,8 @@ def test_bfs_vs_bfs_state_and_reward() -> None:
         assert node in defender_state.performed_nodes
 
     # Verify rewards in latest run and total rewards
-    assert attacker_state.reward == 0
-    assert defender_state.reward == -50
+    assert sim.agent_reward(attacker_state.name) == 0
+    assert sim.agent_reward(defender_state.name) == -50
 
     assert total_reward_attacker == 0
     assert total_reward_defender == -2200
@@ -223,8 +223,8 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
                 states['defender1'].step_performed_nodes:
             defender_actions.append(defender_node.full_name)
 
-        total_reward_defender += defender_state.reward
-        total_reward_attacker += attacker_state.reward
+        total_reward_defender += sim.agent_reward(defender_state.name)
+        total_reward_attacker += sim.agent_reward(attacker_state.name)
 
     assert sim.cur_iter == 637
 
@@ -302,8 +302,8 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
         assert node in defender_state.performed_nodes
 
     # Verify rewards in latest run and total rewards
-    assert attacker_state.reward == 0
-    assert defender_state.reward == -19
+    assert sim.agent_reward(attacker_state.name) == 0
+    assert sim.agent_reward(defender_state.name) == -19
 
     assert total_reward_attacker == 0
     assert total_reward_defender == -11994.0  # It ran for a while

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -7,7 +7,11 @@ Determinism, ttcs, agents, action surfaces, step etc.
 """
 
 from malsim.scenario import create_simulator_from_scenario
-from malsim.mal_simulator import MalSimulatorSettings, TTCMode
+from malsim.mal_simulator import (
+    MalSimulatorSettings,
+    TTCMode,
+    MalSimDefenderState
+)
 
 def test_bfs_vs_bfs_state_and_reward() -> None:
     """
@@ -43,8 +47,8 @@ def test_bfs_vs_bfs_state_and_reward() -> None:
     total_reward_defender = 0.0
     total_reward_attacker = 0.0
 
-    attacker_actions = []
-    defender_actions = []
+    attacker_actions: list[str] = []
+    defender_actions: list[str] = []
 
     states = sim.reset()
 
@@ -64,6 +68,7 @@ def test_bfs_vs_bfs_state_and_reward() -> None:
         states = sim.step(actions)
         attacker_state = states[attacker_agent_name]
         defender_state = states[defender_agent_name]
+        assert isinstance(defender_state, MalSimDefenderState)
 
         # If actions were performed, add them to respective list
         if attacker_node and attacker_node in attacker_state.step_performed_nodes:
@@ -212,12 +217,12 @@ def test_bfs_vs_bfs_state_and_reward_per_step_ttc() -> None:
         states = sim.step(actions)
         attacker_state = states[attacker_agent_name]
         defender_state = states[defender_agent_name]
+        assert isinstance(defender_state, MalSimDefenderState)
 
         # If actions were performed, add them to respective list
-        if attacker_node and attacker_node in \
-                states['attacker1'].step_performed_nodes:
+        if attacker_node and attacker_node in attacker_state.step_performed_nodes:
             attacker_actions.append(attacker_node.full_name)
-            assert attacker_node in states['defender1'].step_all_compromised_nodes
+            assert attacker_node in defender_state.step_all_compromised_nodes
 
         if defender_node and defender_node in \
                 states['defender1'].step_performed_nodes:
@@ -354,6 +359,7 @@ def test_bfs_vs_bfs_state_and_reward_PER_STEP_TRIAL() -> None:
         states = sim.step(actions)
         defender_state = states[defender_agent_name]
         attacker_state = states[attacker_agent_name]
+        assert isinstance(defender_state, MalSimDefenderState)
 
         # If actions were performed, add them to respective list
         if attacker_node and attacker_node in attacker_state.step_performed_nodes:
@@ -494,6 +500,7 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         states = sim.step(actions)
         defender_state = states[defender_agent_name]
         attacker_state = states[attacker_agent_name]
+        assert isinstance(defender_state, MalSimDefenderState)
 
         # If actions were performed, add them to respective list
         if attacker_node and attacker_node in attacker_state.step_performed_nodes:

--- a/tests/envs/test_example_scenarios.py
+++ b/tests/envs/test_example_scenarios.py
@@ -341,7 +341,7 @@ def test_bfs_vs_bfs_state_and_reward_PER_STEP_TRIAL() -> None:
     attacker_state = states[attacker_agent_name]
     defender_state = states[defender_agent_name]
 
-    while True:
+    while not sim.done():
         # Run the simulation until agents are terminated/truncated
         attacker_node = attacker_agent.get_next_action(attacker_state)
         defender_node = defender_agent.get_next_action(defender_state)
@@ -363,14 +363,8 @@ def test_bfs_vs_bfs_state_and_reward_PER_STEP_TRIAL() -> None:
         if defender_node and defender_node in defender_state.step_performed_nodes:
             defender_actions.append(defender_node.full_name)
 
-        total_reward_defender += defender_state.reward
-        total_reward_attacker += attacker_state.reward
-
-        # Break simulation if trunc or term
-        if defender_state.terminated or attacker_state.terminated:
-            break
-        if defender_state.truncated or attacker_state.truncated:
-            break
+        total_reward_defender += sim.agent_reward(defender_state.name)
+        total_reward_attacker += sim.agent_reward(attacker_state.name)
 
     assert sim.cur_iter == 118
 
@@ -448,8 +442,8 @@ def test_bfs_vs_bfs_state_and_reward_PER_STEP_TRIAL() -> None:
         assert node in defender_state.performed_nodes
 
     # Verify rewards in latest run and total rewards
-    assert attacker_state.reward == 0
-    assert defender_state.reward == -19
+    assert sim.agent_reward(attacker_state.name) == 0
+    assert sim.agent_reward(defender_state.name) == -19
 
     assert total_reward_attacker == 0
     assert total_reward_defender == -2133.0
@@ -487,7 +481,7 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
     attacker_state = states[attacker_agent_name]
     defender_state = states[defender_agent_name]
 
-    while True:
+    while not sim.done():
         # Run the simulation until agents are terminated/truncated
         attacker_node = attacker_agent.get_next_action(attacker_state)
         defender_node = defender_agent.get_next_action(defender_state)
@@ -509,14 +503,8 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         if defender_node and defender_node in defender_state.step_performed_nodes:
             defender_actions.append(defender_node.full_name)
 
-        total_reward_defender += defender_state.reward
-        total_reward_attacker += attacker_state.reward
-
-        # Break simulation if trunc or term
-        if defender_state.terminated or attacker_state.terminated:
-            break
-        if defender_state.truncated or attacker_state.truncated:
-            break
+        total_reward_defender += sim.agent_reward(defender_state.name)
+        total_reward_attacker += sim.agent_reward(attacker_state.name)
 
     assert sim.cur_iter == 11
 
@@ -558,8 +546,8 @@ def test_bfs_vs_bfs_state_and_reward_expected_value_ttc() -> None:
         assert node in defender_state.performed_nodes
 
     # Verify rewards in latest run and total rewards
-    assert attacker_state.reward == 0
-    assert defender_state.reward == -19
+    assert sim.agent_reward(attacker_state.name) == 0
+    assert sim.agent_reward(defender_state.name) == -19
 
     assert total_reward_attacker == 0
     assert total_reward_defender == -100.0

--- a/tests/envs/test_vectorized_obs_mal_simulator.py
+++ b/tests/envs/test_vectorized_obs_mal_simulator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from maltoolbox.attackgraph import AttackGraph
-from malsim.mal_simulator import MalSimulator
+from malsim.mal_simulator import MalSimulator, MalSimAttackerState
 from malsim.envs import MalSimVectorizedObsEnv
 from malsim.scenario import load_scenario
 
@@ -524,6 +524,8 @@ def test_malsimulator_observe_and_reward_attacker_entrypoints(
         ):
 
         attacker_state = env.get_agent_state(attacker_name)
+        assert isinstance(attacker_state, MalSimAttackerState)
+
         node = env.index_to_node(index)
         if state == -1:
             assert node not in attacker_state.entry_points

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -144,11 +144,11 @@ def test_attacker_step(
 
     # Can not attack the notPresent step
     defense_step = get_node(attack_graph, 'OS App:notPresent')
-    actions = sim._attacker_step(attacker_agent, [defense_step])
+    actions, _ = sim._attacker_step(attacker_agent, [defense_step])
     assert not actions
 
     attack_step = get_node(attack_graph, 'OS App:attemptRead')
-    actions = sim._attacker_step(attacker_agent, [attack_step])
+    actions, _ = sim._attacker_step(attacker_agent, [attack_step])
     assert actions  == {attack_step}
 
 
@@ -200,13 +200,13 @@ def test_attacker_step_rewards_cumulative(
 
     states = sim.step({attacker_name: [attempt_read]})
     attacker_state = states[attacker_name]
-    assert attacker_state.reward == (
+    assert sim.agent_reward(attacker_state.name) == (
         node_rewards[entry_point] + node_rewards[attempt_read]
     )
 
     states = sim.step({attacker_name: [access_network_and_conn]})
     attacker_state = states[attacker_name]
-    assert attacker_state.reward == (
+    assert sim.agent_reward(attacker_state.name) == (
         node_rewards[entry_point]
         + node_rewards[attempt_read]
         + node_rewards[access_network_and_conn]
@@ -240,13 +240,11 @@ def test_attacker_step_rewards_one_off(
     sim.register_attacker(attacker_name, {entry_point})
     sim.reset()
 
-    states = sim.step({attacker_name: [attempt_read]})
-    attacker_state = states[attacker_name]
-    assert attacker_state.reward == node_rewards[attempt_read]
+    sim.step({attacker_name: [attempt_read]})
+    assert sim.agent_reward(attacker_name) == node_rewards[attempt_read]
 
-    states = sim.step({attacker_name: [access_network_and_conn]})
-    attacker_state = states[attacker_name]
-    assert attacker_state.reward == node_rewards[access_network_and_conn]
+    sim.step({attacker_name: [access_network_and_conn]})
+    assert sim.agent_reward(attacker_name) == node_rewards[access_network_and_conn]
 
 
 def test_defender_step_rewards_cumulative(
@@ -275,19 +273,17 @@ def test_defender_step_rewards_cumulative(
     sim.register_attacker(attacker_name, {entry_point})
     sim.reset()
 
-    states = sim.step({
+    sim.step({
         attacker_name: [attempt_read]
     })
-    defender_state = states[defender_name]
-    assert defender_state.reward == - (
+    assert sim.agent_reward(defender_name) == - (
         node_rewards[entry_point] + node_rewards[attempt_read]
     )
 
-    states = sim.step({
+    sim.step({
         attacker_name: [access_network_and_conn]
     })
-    defender_state = states[defender_name]
-    assert defender_state.reward == - (
+    assert sim.agent_reward(defender_name) == - (
         node_rewards[entry_point]
         + node_rewards[attempt_read]
         + node_rewards[access_network_and_conn]
@@ -329,13 +325,13 @@ def test_defender_step_rewards_one_off(
         attacker_name: [attempt_read]
     })
     defender_state = states[defender_name]
-    assert defender_state.reward == - node_rewards[attempt_read]
+    assert sim.agent_reward(defender_state.name) == - node_rewards[attempt_read]
 
     states = sim.step({
         attacker_name: [access_network_and_conn]
     })
     defender_state = states[defender_name]
-    assert defender_state.reward == - node_rewards[access_network_and_conn]
+    assert sim.agent_reward(defender_state.name) == - node_rewards[access_network_and_conn]
 
 
 # TODO: Some of the assert values in this test have changed when updating the

--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -416,6 +416,9 @@ def test_agent_state_views_simple(corelang_lang_graph: LanguageGraph, model: Mod
     })
     asv = state_views['attacker']
     dsv = state_views['defender']
+    assert isinstance(asv, MalSimAttackerState)
+    assert isinstance(dsv, MalSimDefenderState)
+
     assert asv.step_performed_nodes == {os_app_attempt_deny}
     assert dsv.step_performed_nodes == {program2_not_present}
 
@@ -439,6 +442,9 @@ def test_agent_state_views_simple(corelang_lang_graph: LanguageGraph, model: Mod
     })
     asv = state_views['attacker']
     dsv = state_views['defender']
+    assert isinstance(asv, MalSimAttackerState)
+    assert isinstance(dsv, MalSimDefenderState)
+
     assert asv.step_performed_nodes == {os_app_spec_access}
     assert dsv.step_performed_nodes == set()
     assert os_app_access_netcon in asv.action_surface
@@ -458,6 +464,9 @@ def test_agent_state_views_simple(corelang_lang_graph: LanguageGraph, model: Mod
     })
     asv = state_views['attacker']
     dsv = state_views['defender']
+    assert isinstance(asv, MalSimAttackerState)
+    assert isinstance(dsv, MalSimDefenderState)
+
     assert asv.step_performed_nodes == set()
     assert dsv.step_performed_nodes == {os_app_not_present}
     assert asv.step_action_surface_additions == set()


### PR DESCRIPTION
In current main, `MalSimAgentState` stores all info about agents.
These objects are mutable in the simulator, but the simulator returns `MalSimAgentStateView` to users which are read only projections of the agent states.

In this PR I have made MalSimAgentState immutable. This means that they are recreated in every step based on what happened in that step. This also removes the need of `MalSimAgentStateView`

Reward and termination is not stored in the agent state, but instead in the simulator. 

Some additions is also that I added `.done()` which can tell a user when the simulation is done (can be used in their simulation loop). I also added some other helpers and split up some code to make the immutable agent states work and also just because it looked nice.

Some of the changes are just moving methods around in the mal_simulator module into a more logical order.

Please take a look and see what you think about this PR.