### PR TITLE
Add 'observed_nodes' and 'step_observed_nodes' to defender state

### DIFF
--- a/tests/test_mal_simulator.py
+++ b/tests/test_mal_simulator.py
@@ -665,7 +665,7 @@ def test_simulator_false_positives() -> None:
     assert isinstance(attacker_state, MalSimAttackerState)
 
     # Should be false positive in defender state
-    assert defender_state.compromised_nodes > attacker_state.performed_nodes
+    assert len(defender_state.observed_nodes) > len(defender_state.compromised_nodes)
 
 
 def test_simulator_false_negatives() -> None:
@@ -689,7 +689,7 @@ def test_simulator_false_negatives() -> None:
     assert isinstance(attacker_state, MalSimAttackerState)
 
     # Should be false negatives in defender state
-    assert defender_state.compromised_nodes < attacker_state.performed_nodes
+    assert len(defender_state.observed_nodes) < len(defender_state.compromised_nodes)
 
 
 def test_simulator_no_fpr_fnr() -> None:


### PR DESCRIPTION
Use false positives, false negatives and observability to generate `observed_nodes`.